### PR TITLE
354: update domestic standing order intent name

### DIFF
--- a/config/7.0/obdemo-bank/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -155,7 +155,7 @@
             "type": "application/x-groovy",
             "file": "ProcessPaymentConsent.groovy",
             "args": {
-              "routeArgObjDomesticPaymentConsent": "domesticStandingOrderPaymentIntent",
+              "routeArgObjDomesticPaymentConsent": "domesticStandingOrderIntent",
               "routeArgObjApiClient": "apiClient",
               "routeArgConsentIdPrefix": "PDSOC_"
             }

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/GetResourceOwnerIdFromConsent.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/GetResourceOwnerIdFromConsent.groovy
@@ -9,10 +9,10 @@ enum IntentType {
     ACCOUNT_ACCESS_CONSENT("AAC_", "accountAccessIntent"),
     PAYMENT_DOMESTIC_CONSENT("PDC_", "domesticPaymentIntent"),
     PAYMENT_DOMESTIC_SCHEDULED_CONSENT("PDSC_", "domesticScheduledPaymentIntent"),
-    PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT("PDSOC_", "domesticStandingOrderPaymentIntent"),
+    PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT("PDSOC_", "domesticStandingOrderIntent"),
     PAYMENT_INTERNATIONAL_CONSENT("PIC_", "internationalPaymentIntent"),
     PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT("PISC_", "internationalScheduledPaymentIntent"),
-    PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT("PISOC_", "internationalStandingOrdersPaymentIntent"),
+    PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT("PISOC_", "internationalStandingOrdersIntent"),
     PAYMENT_FILE_CONSENT("PFC_", "filePaymentIntent"),
     FUNDS_CONFIRMATION_CONSENT("FCC_", "fundsConfirmationIntent"),
     DOMESTIC_VRP_PAYMENT_CONSENT("DVRP_", "domesticVrpPaymentIntent")

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/RepoConsent.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/RepoConsent.groovy
@@ -149,10 +149,10 @@ enum IntentType {
     ACCOUNT_ACCESS_CONSENT("AAC_", "accountAccessIntent"),
     PAYMENT_DOMESTIC_CONSENT("PDC_","domesticPaymentIntent"),
     PAYMENT_DOMESTIC_SCHEDULED_CONSENT("PDSC_", "domesticScheduledPaymentIntent"),
-    PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT("PDSOC_", "domesticStandingOrderPaymentIntent"),
+    PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT("PDSOC_", "domesticStandingOrderIntent"),
     PAYMENT_INTERNATIONAL_CONSENT("PIC_", "internationalPaymentIntent"),
     PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT("PISC_", "internationalScheduledPaymentIntent"),
-    PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT("PISOC_", "internationalStandingOrderPaymentIntent"),
+    PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT("PISOC_", "internationalStandingOrderIntent"),
     PAYMENT_FILE_CONSENT("PFC_", "filePaymentIntent"),
     FUNDS_CONFIRMATION_CONSENT("FCC_", "fundsConfirmationIntent"),
     DOMESTIC_VRP_PAYMENT_CONSENT("DVRP_", "domesticVrpPaymentIntent")


### PR DESCRIPTION
- Updated `domesticStandingOrderPaymentIntent` to `domesticStandingOrderIntent`
- updated `internationalStandingOrderPaymentIntent` to `internationalStandingOrderIntent`
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/354