### PR TITLE
306 ig pods restart randomly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ docker/7.0/ig/scripts/
 /docker/gatling/gradlew
 /docker/gatling/gradlew.bat
 /docker/gatling/gradle/
+lib/*.jar

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessDetachedSig.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessDetachedSig.groovy
@@ -260,7 +260,9 @@ def validateEncodedPayload(String payload, String routeArgJwkUrl, String jwtPayl
 def getRSAKeyFromJwks(String routeArgJwkUrl, JWSHeader jwsHeader) {
     JWKSet jwkSet
     try {
-        jwkSet = JWKSet.load(new URL(routeArgJwkUrl));
+        //adding connectTimeout = 5000 ms, readTimeout = 5000 ms, sizeLimit = 1000000 bytes (1Mb) to avoid blocked threads.
+        //There's an issue which leaves connections hanging and leads to threads getting blocked
+        jwkSet = JWKSet.load(new URL(routeArgJwkUrl), 10000, 10000, 1000000);
     }
     catch (java.lang.Exception e) {
         logger.error(SCRIPT_NAME + "Exception getting JWK set: " + e);


### PR DESCRIPTION
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/306
Description: There's an issue with the nimbus jose library used to retrieve the jwk sets which in combination which IG causes thread to hang if for some reason the connection is not closed by nimbus JWKSet.load method.