### PR TITLE
505: After a payment is submitted the consent status must be changed to Consumed

### DIFF
--- a/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
@@ -13,6 +13,19 @@
     "config": {
       "filters": [
         {
+          "comment": "Change the payment intent status to Consumed",
+          "name": "ConsumeThePaymentIntent",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsumeThePaymentIntent.groovy",
+            "clientHandler": "IDMClientHandler",
+            "args": {
+              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -13,6 +13,19 @@
     "config": {
       "filters": [
         {
+          "comment": "Change the payment intent status to Consumed",
+          "name": "ConsumeThePaymentIntent",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsumeThePaymentIntent.groovy",
+            "clientHandler": "IDMClientHandler",
+            "args": {
+              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
@@ -13,6 +13,19 @@
     "config": {
       "filters": [
         {
+          "comment": "Change the payment intent status to Consumed",
+          "name": "ConsumeThePaymentIntent",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsumeThePaymentIntent.groovy",
+            "clientHandler": "IDMClientHandler",
+            "args": {
+              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -13,6 +13,19 @@
     "config": {
       "filters": [
         {
+          "comment": "Change the payment intent status to Consumed",
+          "name": "ConsumeThePaymentIntent",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsumeThePaymentIntent.groovy",
+            "clientHandler": "IDMClientHandler",
+            "args": {
+              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
@@ -13,6 +13,19 @@
     "config": {
       "filters": [
         {
+          "comment": "Change the payment intent status to Consumed",
+          "name": "ConsumeThePaymentIntent",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsumeThePaymentIntent.groovy",
+            "clientHandler": "IDMClientHandler",
+            "args": {
+              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/ConsumeThePaymentIntent.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/ConsumeThePaymentIntent.groovy
@@ -1,0 +1,105 @@
+import groovy.json.JsonOutput
+
+SCRIPT_NAME = "[ConsumeThePaymentIntent] - "
+logger.debug(SCRIPT_NAME + "Running...")
+
+/**
+ *  definitions
+ */
+def buildPatchRequest() {
+    def body = [];
+
+    body.push([
+            "operation": "replace",
+            "field"    : "/Data/Status",
+            "value"    : "Consumed"
+    ]);
+
+    return body
+}
+
+enum IntentType {
+    ACCOUNT_ACCESS_CONSENT("AAC_", "accountAccessIntent"),
+    PAYMENT_DOMESTIC_CONSENT("PDC_","domesticPaymentIntent"),
+    PAYMENT_DOMESTIC_SCHEDULED_CONSENT("PDSC_", "domesticScheduledPaymentIntent"),
+    PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT("PDSOC_", "domesticStandingOrderIntent"),
+    PAYMENT_INTERNATIONAL_CONSENT("PIC_", "internationalPaymentIntent"),
+    PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT("PISC_", "internationalScheduledPaymentIntent"),
+    PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT("PISOC_", "internationalStandingOrderIntent"),
+    PAYMENT_FILE_CONSENT("PFC_", "filePaymentIntent"),
+    FUNDS_CONFIRMATION_CONSENT("FCC_", "fundsConfirmationIntent"),
+    DOMESTIC_VRP_PAYMENT_CONSENT("DVRP_", "domesticVrpPaymentIntent")
+
+    private String intentIdPrefix;
+    private String consentObject;
+
+    IntentType(String intentIdPrefix, String consentObject) {
+        this.intentIdPrefix = intentIdPrefix
+        this.consentObject = consentObject
+    }
+
+    static IntentType identify(String intentId) {
+        IntentType[] types = values()
+        Optional<IntentType> optional = Arrays.stream(types).filter(type -> intentId.startsWith(type.intentIdPrefix)).findFirst()
+        if (optional.isPresent()) {
+            return optional.get()
+        }
+        return null;
+    }
+
+    String getIntentIdPrefix() {
+        return intentIdPrefix
+    }
+    String getConsentObject(){
+        return consentObject
+    }
+}
+/**
+ * End definitions
+ */
+
+/**
+ * start script
+ */
+next.handle(context, request).thenOnResult({ response ->
+    //Verify the response status
+    if (response.status != Status.CREATED) {
+        //This script should be executed only if the response status is 201 CREATED
+        logger.debug(SCRIPT_NAME + "Skipping the filter because the response status is " + response.status)
+    } else {
+        // If the response status is 201 CREATED, the intent status should be changed to Consumed
+        logger.debug(SCRIPT_NAME + "The response status is " + response.status + ". The intent status will be updated to Consumed.")
+
+        //Get the intent Id from the request body
+        def intentId = request.entity.getJson().Data.ConsentId
+        logger.debug(SCRIPT_NAME + "The intent id is " + intentId)
+
+        def intentObject = ""
+        def intentType = IntentType.identify(intentId)
+
+        if(intentType){
+            intentObject = intentType.getConsentObject();
+        } else {
+            message = "Can't parse consent type from inbound request, unknown consent type [" + intentType + "]."
+            logger.error(SCRIPT_NAME + message)
+            response.status = Status.BAD_REQUEST
+            response.entity = "{ \"error\":\"" + message + "\"}"
+            return response
+        }
+
+        def requestUri = routeArgIdmBaseUri + "/openidm/managed/" + intentObject + "/" + intentId + "?_fields=_id,Data,user/_id,accounts,account,apiClient/oauth2ClientId,apiClient/name";
+        logger.debug(SCRIPT_NAME + "The request uri is " + requestUri)
+
+        Request patchRequest = new Request();
+        patchRequest.setMethod('POST');
+        patchRequest.setUri(requestUri + "&_action=patch");
+        patchRequest.getHeaders().add("Content-Type", "application/json");
+        patchRequest.setEntity(JsonOutput.toJson(buildPatchRequest()))
+
+        http.send(patchRequest).thenAsync(patchResponse -> {
+            def responseStatus = patchResponse.getStatus();
+            logger.debug(SCRIPT_NAME + "Get API client response status: " + responseStatus)
+            logger.debug(SCRIPT_NAME + "The intent status was changed to Consumed")
+        })
+    }
+})

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessDetachedSig.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessDetachedSig.groovy
@@ -406,7 +406,7 @@ def getCriticalHeaderParameters() {
 }
 
 /**
- * Builds the signature validation failur error response
+ * Builds the signature validation failure error response
  * @return error response
  */
 def getSignatureValidationErrorResponse() {


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/505

- Created the ConsumeThePaymentIntent groovy script to change the payment intent status to **Consumed** after the payment was submitted
- If the intent status is Consumed, the funds confirmation request should return a BAD REQUEST error
  From the [OB documentation](https://openbankinguk.github.io/read-write-api-site3/v3.1.8/resources-and-data-models/pisp/international-payment-consents.html#get-international-payment-consents-consentid-funds-confirmation):
  An ASPSP can only respond to a funds confirmation request if the payment consent (international payment, international scheduled payment) resource has an Authorised status. If the status is not Authorised, an ASPSP must respond with a 400 (Bad Request) and a UK.OBIE.Resource.InvalidConsentStatus error code.

