### PR TITLE
506: Improving logging pattern

### DIFF
--- a/config/7.0/obdemo-bank/ig/config/dev/config/logback.xml
+++ b/config/7.0/obdemo-bank/ig/config/dev/config/logback.xml
@@ -16,9 +16,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%nopex[%thread] %highlight(%-5level) %boldWhite(%logger{35}) -
-                %message%n%highlight(%rootException{short})
-            </pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %boldWhite(%logger{35}) - %message%n%highlight(%rootException{short})</pattern>
         </encoder>
     </appender>
      

--- a/config/7.0/obdemo-bank/ig/config/prod/config/logback.xml
+++ b/config/7.0/obdemo-bank/ig/config/prod/config/logback.xml
@@ -16,9 +16,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%nopex[%thread] %highlight(%-5level) %boldWhite(%logger{35}) -
-                %message%n%highlight(%rootException{short})
-            </pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %nopex[%thread] %highlight(%-5level) %boldWhite(%logger{35}) - %message%n%highlight(%rootException{short})</pattern>
         </encoder>
     </appender>
      


### PR DESCRIPTION
Changing logging pattern to log messages on a single line, adding a timestamp to the start of the line and logging full exception stacktraces (for dev env only, to aid debugging)

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/506