### PR TITLE
506: Removing ANSI color codes from logging

### DIFF
--- a/config/7.0/obdemo-bank/ig/config/dev/config/logback.xml
+++ b/config/7.0/obdemo-bank/ig/config/dev/config/logback.xml
@@ -16,7 +16,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %boldWhite(%logger{35}) - %message%n%highlight(%rootException{short})</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %message%n%xException</pattern>
         </encoder>
     </appender>
      

--- a/config/7.0/obdemo-bank/ig/config/prod/config/logback.xml
+++ b/config/7.0/obdemo-bank/ig/config/prod/config/logback.xml
@@ -16,7 +16,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %nopex[%thread] %highlight(%-5level) %boldWhite(%logger{35}) - %message%n%highlight(%rootException{short})</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %nopex[%thread] %-5level %logger{35} - %message%n%rootException{short}</pattern>
         </encoder>
     </appender>
      


### PR DESCRIPTION
Removing ANSI color codes from IG logging, this makes logs more readable when viewed in tools which do not process the ANSI codes. This produces a log output which is similar to our other java apps.

Output can be viewed here: https://argo.dev.forgerock.financial/applications/ig-securebanking-dbadham-fr?resource=&node=%2FPod%2Fdbadham-fr%2Fig-6dfc9ddc98-d68x5%2F0&tab=logs

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/506