### PR TITLE
503: Updating merge.yml action to build the maven modules prior to building the docker image

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -25,7 +25,20 @@ jobs:
       # Configure docker to use the gcloud command-line tool as a credential helper
       - run: |
           gcloud auth configure-docker
-      
+
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
+
+      - name: Build maven
+        run: |
+          mvn clean install
+        env:
+          MAVEN_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
+
       - name: docker build
         run: |
           make build-docker-ig tag=${{ env.GIT_SHA_SHORT }}


### PR DESCRIPTION
https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-gateway/pull/162 was merged previously, this has broken the dev env as it has produced a docker image that is missing the jwks ig extension module.

Updating the github action on merge to do the maven build.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/503