### PR TITLE
Adding failure handlers for policy validation error

### DIFF
--- a/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
@@ -73,7 +73,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
@@ -42,6 +42,21 @@
           }
         },
         {
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
           "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
           "name" : "OAuth2ResourceServerFilter-OB",
           "type" : "OAuth2ResourceServerFilter",
@@ -56,25 +71,11 @@
                 "delegate": {
                   "comment":"resolve access tokens and retrieve metadata about the token. The endpoint typically returns the time until the token expires, the OAuth 2.0 scopes associated with the token, and potentially other information",
                   "name": "token-resolver-1",
-                  "type": "TokenIntrospectionAccessTokenResolver",
+                  "type": "StatelessAccessTokenResolver",
                   "config": {
-                    "endpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/introspect",
-                    "providerHandler": {
-                      "type": "Chain",
-                      "config": {
-                        "filters": [
-                          {
-                            "type": "HttpBasicAuthenticationClientFilter",
-                            "config": {
-                              "username": "&{ig.agent.id}",
-                              "passwordSecretId": "ig.agent.password",
-                              "secretsProvider": "SystemAndEnvSecretStore-IAM"
-                            }
-                          }
-                        ],
-                        "handler": "ForgeRockClientHandler"
-                      }
-                    }
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }
@@ -90,21 +91,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "client_credentials"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
@@ -69,7 +69,6 @@
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
                 "delegate": {
-                  "comment":"resolve access tokens and retrieve metadata about the token. The endpoint typically returns the time until the token expires, the OAuth 2.0 scopes associated with the token, and potentially other information",
                   "name": "token-resolver-1",
                   "type": "StatelessAccessTokenResolver",
                   "config": {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
@@ -73,8 +73,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
@@ -90,7 +90,6 @@
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
                 "delegate": {
-                  "comment":"resolve access tokens and retrieve metadata about the token. The endpoint typically returns the time until the token expires, the OAuth 2.0 scopes associated with the token, and potentially other information",
                   "name": "token-resolver-1",
                   "type": "StatelessAccessTokenResolver",
                   "config": {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
@@ -63,6 +63,21 @@
           }
         },
         {
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
           "comment": "Check access token",
           "name" : "OAuth2ResourceServerFilter-OBIE",
           "type" : "OAuth2ResourceServerFilter",
@@ -92,22 +107,6 @@
             }
           }
         },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
           "comment": "Check consent authorised via AM authz policy",
           "name" : "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
           "type" : "PolicyEnforcementFilter",

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
@@ -112,7 +112,14 @@
               "tpp_cert_id" : [ "${attributes.tppId}" ],
               "intent_id": [ "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}" ]
             },
-            "amService" : "AmService-OBIE"
+            "amService" : "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
@@ -94,8 +94,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
@@ -94,7 +94,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/11-ob-account-access.json
@@ -78,20 +78,28 @@
           }
         },
         {
-          "comment": "Check access token",
-          "name" : "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
+          "name" : "OAuth2ResourceServerFilter-OB",
           "type" : "OAuth2ResourceServerFilter",
           "config" : {
             "scopes" : [ "accounts", "openid" ],
             "requireHttps" : false,
             "realm" : "OpenIG",
             "accessTokenResolver" : {
-              "type": "StatelessAccessTokenResolver",
+              "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
-               }
+                "delegate": {
+                  "comment":"resolve access tokens and retrieve metadata about the token. The endpoint typically returns the time until the token expires, the OAuth 2.0 scopes associated with the token, and potentially other information",
+                  "name": "token-resolver-1",
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
+              }
             }
           }
         },
@@ -107,6 +115,7 @@
             }
           }
         },
+        {
           "comment": "Check consent authorised via AM authz policy",
           "name" : "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
           "type" : "PolicyEnforcementFilter",

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -90,7 +90,6 @@
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
                 "delegate": {
-                  "comment":"resolve access tokens and retrieve metadata about the token. The endpoint typically returns the time until the token expires, the OAuth 2.0 scopes associated with the token, and potentially other information",
                   "name": "token-resolver-1",
                   "type": "StatelessAccessTokenResolver",
                   "config": {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -63,6 +63,21 @@
           }
         },
         {
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
           "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
           "name" : "OAuth2ResourceServerFilter-OB",
           "type" : "OAuth2ResourceServerFilter",
@@ -97,21 +112,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "authorization_code"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -112,7 +112,14 @@
               "tpp_cert_id" : [ "${attributes.tppId}" ],
               "intent_id": [ "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}" ]
             },
-            "amService" : "AmService-OBIE"
+            "amService" : "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -94,8 +94,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -94,7 +94,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -63,19 +63,27 @@
           }
         },
         {
-          "comment": "Check access token",
-          "name" : "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
+          "name" : "OAuth2ResourceServerFilter-OB",
           "type" : "OAuth2ResourceServerFilter",
           "config" : {
             "scopes" : [ "accounts", "openid" ],
             "requireHttps" : false,
             "realm" : "OpenIG",
             "accessTokenResolver" : {
-              "type": "StatelessAccessTokenResolver",
+              "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "comment":"resolve access tokens and retrieve metadata about the token. The endpoint typically returns the time until the token expires, the OAuth 2.0 scopes associated with the token, and potentially other information",
+                  "name": "token-resolver-1",
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -62,22 +62,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -91,21 +110,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "authorization_code"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -93,8 +93,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -160,7 +160,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -93,7 +93,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/31-ob-payment-consent.json
@@ -98,7 +98,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/31-ob-payment-consent.json
@@ -98,8 +98,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
@@ -76,22 +76,26 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
@@ -76,6 +76,21 @@
           }
         },
         {
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
           "comment": "Check certificate bound access token",
           "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
@@ -109,21 +124,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "authorization_code"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
@@ -107,7 +107,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
@@ -107,8 +107,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
@@ -190,7 +190,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -63,22 +63,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -92,21 +111,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "client_credentials"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -161,7 +161,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -94,8 +94,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -94,7 +94,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -107,7 +107,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -107,8 +107,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -104,26 +104,11 @@
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
                 "delegate": {
-                  "name": "token-resolver-1",
-                  "type": "TokenIntrospectionAccessTokenResolver",
+                  "type": "StatelessAccessTokenResolver",
                   "config": {
-                    "endpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/introspect",
-                    "providerHandler": {
-                      "type": "Chain",
-                      "config": {
-                        "filters": [
-                          {
-                            "type": "HttpBasicAuthenticationClientFilter",
-                            "config": {
-                              "username": "&{ig.agent.id}",
-                              "passwordSecretId": "ig.agent.password",
-                              "secretsProvider": "SystemAndEnvSecretStore-IAM"
-                            }
-                          }
-                        ],
-                        "handler": "ForgeRockClientHandler"
-                      }
-                    }
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -76,22 +76,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -105,21 +124,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "authorization_code"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -107,7 +107,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -107,8 +107,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -190,7 +190,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -63,22 +63,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -92,21 +111,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "client_credentials"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -161,7 +161,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -94,8 +94,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -94,7 +94,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -98,7 +98,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -87,7 +87,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -95,26 +95,11 @@
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
                 "delegate": {
-                  "name": "token-resolver-1",
-                  "type": "TokenIntrospectionAccessTokenResolver",
+                  "type": "StatelessAccessTokenResolver",
                   "config": {
-                    "endpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/introspect",
-                    "providerHandler": {
-                      "type": "Chain",
-                      "config": {
-                        "filters": [
-                          {
-                            "type": "HttpBasicAuthenticationClientFilter",
-                            "config": {
-                              "username": "&{ig.agent.id}",
-                              "passwordSecretId": "ig.agent.password",
-                              "secretsProvider": "SystemAndEnvSecretStore-IAM"
-                            }
-                          }
-                        ],
-                        "handler": "ForgeRockClientHandler"
-                      }
-                    }
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -98,8 +98,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
@@ -76,22 +76,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -105,21 +124,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "authorization_code"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
@@ -107,7 +107,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
@@ -208,7 +208,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/41-ob-domestic-standing-order-submission.json
@@ -107,8 +107,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/42-ob-domestic-standing-order-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/42-ob-domestic-standing-order-access.json
@@ -63,22 +63,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -92,21 +111,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "client_credentials"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/42-ob-domestic-standing-order-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/42-ob-domestic-standing-order-access.json
@@ -161,7 +161,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/42-ob-domestic-standing-order-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/42-ob-domestic-standing-order-access.json
@@ -94,8 +94,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/42-ob-domestic-standing-order-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/42-ob-domestic-standing-order-access.json
@@ -94,7 +94,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -98,7 +98,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -95,26 +95,11 @@
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
                 "delegate": {
-                  "name": "token-resolver-1",
-                  "type": "TokenIntrospectionAccessTokenResolver",
+                  "type": "StatelessAccessTokenResolver",
                   "config": {
-                    "endpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/introspect",
-                    "providerHandler": {
-                      "type": "Chain",
-                      "config": {
-                        "filters": [
-                          {
-                            "type": "HttpBasicAuthenticationClientFilter",
-                            "config": {
-                              "username": "&{ig.agent.id}",
-                              "passwordSecretId": "ig.agent.password",
-                              "secretsProvider": "SystemAndEnvSecretStore-IAM"
-                            }
-                          }
-                        ],
-                        "handler": "ForgeRockClientHandler"
-                      }
-                    }
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -98,8 +98,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -76,22 +76,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -105,21 +124,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "authorization_code"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -107,7 +107,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -107,8 +107,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -199,7 +199,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -63,22 +63,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -92,21 +111,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "client_credentials"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -161,7 +161,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -94,8 +94,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -94,7 +94,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -62,22 +62,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -91,21 +110,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "authorization_code"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -93,8 +93,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -160,7 +160,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -93,7 +93,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -98,7 +98,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -95,26 +95,11 @@
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
                 "delegate": {
-                  "name": "token-resolver-1",
-                  "type": "TokenIntrospectionAccessTokenResolver",
+                  "type": "StatelessAccessTokenResolver",
                   "config": {
-                    "endpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/introspect",
-                    "providerHandler": {
-                      "type": "Chain",
-                      "config": {
-                        "filters": [
-                          {
-                            "type": "HttpBasicAuthenticationClientFilter",
-                            "config": {
-                              "username": "&{ig.agent.id}",
-                              "passwordSecretId": "ig.agent.password",
-                              "secretsProvider": "SystemAndEnvSecretStore-IAM"
-                            }
-                          }
-                        ],
-                        "handler": "ForgeRockClientHandler"
-                      }
-                    }
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -98,8 +98,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
@@ -76,22 +76,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -105,21 +124,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "authorization_code"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
@@ -107,7 +107,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
@@ -107,8 +107,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/51-ob-international-schduled-payment-submission.json
@@ -199,7 +199,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -63,22 +63,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -92,21 +111,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "client_credentials"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -161,7 +161,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -94,8 +94,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -94,7 +94,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -62,22 +62,41 @@
           }
         },
         {
-          "comment": "Check incoming access token",
-          "name": "OAuth2ResourceServerFilter-OBIE",
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Check certificate bound access token",
+          "name": "OAuth2ResourceServerFilter-OB",
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments", "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
             "accessTokenResolver": {
-              "type": "StatelessAccessTokenResolver",
+              "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
-                "secretsProvider": "SecretsProvider-AmJWK",
-                "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                "verificationSecretId": "any.value.in.regex.format"
+                "delegate": {
+                  "type": "StatelessAccessTokenResolver",
+                  "config": {
+                    "secretsProvider": "SecretsProvider-AmJWK",
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
+                  }
+                }
               }
             }
           }
@@ -91,21 +110,6 @@
             "file": "GrantTypeVerifier.groovy",
             "args": {
               "allowedGrantType": "authorization_code"
-            }
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -93,8 +93,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -160,7 +160,14 @@
                 "${request.method}"
               ]
             },
-            "amService": "AmService-OBIE"
+            "amService": "AmService-OBIE",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnPolicyValidationError.groovy"
+              }
+            }
           }
         },
         {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -93,7 +93,8 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}"
+                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
               }

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessAccountConsent.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessAccountConsent.groovy
@@ -11,6 +11,10 @@ SCRIPT_NAME = "[ProcessAccountConsent] - "
 logger.debug(SCRIPT_NAME + "Running...")
 
 def oauth2ClientId = contexts.oauth2.accessToken.info.client_id
+if (oauth2ClientId == null || oauth2ClientId == "") {
+    // in case of client credentials grant
+    oauth2ClientId = contexts.oauth2.accessToken.info.sub
+}
 def method = request.method
 
 switch(method.toUpperCase()) {

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessDetachedSig.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessDetachedSig.groovy
@@ -105,6 +105,11 @@ if (routeArgClientIdFieldName == "client_id") {
 }
 
 if (tppClientId == null) {
+    // in case of client credentials grant
+    tppClientId = contexts.oauth2.accessToken.info.sub
+}
+
+if (tppClientId == null) {
     message = "Cannot obtain TPP client id from the access token"
     logger.error(SCRIPT_NAME + message)
     response.status = Status.BAD_REQUEST

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessPaymentConsent.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessPaymentConsent.groovy
@@ -10,6 +10,11 @@ SCRIPT_NAME = "[ProcessPaymentConsent] - "
 logger.debug(SCRIPT_NAME + "Running...")
 
 def apiClientId = contexts.oauth2.accessToken.info.client_id
+if (apiClientId == null || apiClientId == "") {
+    // in case of client credentials grant
+    apiClientId = contexts.oauth2.accessToken.info.sub
+}
+
 def method = request.method
 
 switch(method.toUpperCase()) {

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/RepoConsent.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/RepoConsent.groovy
@@ -304,7 +304,7 @@ if (request.getMethod() == "GET") {
         def patchResponseObject = patchResponseContent.getJson();
 
         if(patchResponseObject.apiClient == null){
-            message = "Orfan consent, The consent requested to patch with id [" + intentResponseObject._id + "] doesn't have a apiClient related."
+            message = "Orfan consent, The consent requested to patch doesn't have an apiClient related."
             logger.error(SCRIPT_NAME + message)
             response.status = Status.BAD_REQUEST
             response.entity = "{ \"error\":\"" + message + "\"}"

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/ReturnPolicyValidationError.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/ReturnPolicyValidationError.groovy
@@ -1,0 +1,9 @@
+SCRIPT_NAME = "[ReturnPolicyValidationError] - "
+logger.debug(SCRIPT_NAME + "Running...")
+
+def response = new Response(Status.UNAUTHORIZED);
+message = "policy_validation_failed"
+logger.error(SCRIPT_NAME + message)
+response.setEntity("{ \"error\":\"" + message + "\"}")
+
+return response


### PR DESCRIPTION
Issues: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/510
           https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/516

Adding a failure handler to better highlight errors return by the PolicyEnforcementFilter for the cases when the policy validation fails.

Adding fixes for functional tests, thumbprint validation, and grant validation.