### PR TITLE
463: Adding international standing order consent PATCH/GET case in the repo consent script

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
@@ -181,6 +181,19 @@ def convertIDMResponse(intentResponseObject, intentType) {
                     "oauth2ClientName"     : intentResponseObject.apiClient.name
             ]
             break
+        case IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT:
+            responseObj = [
+                    "id"                   : intentResponseObject._id,
+                    "data"                 : intentResponseObject.Data,
+                    // RS expect 'Data' instead 'data' to deserialize the json to OB object
+                    // TODO make it compatible with RS, until fixed on https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/522
+                    // It's a duplication only to be compatible temporary, when the issue has been fixed delete 'data' and 'Data'
+                    "Data"                 : intentResponseObject.Data,
+                    "resourceOwnerUsername": intentResponseObject.user ? intentResponseObject.user._id : null,
+                    "oauth2ClientId"       : intentResponseObject.apiClient.oauth2ClientId,
+                    "oauth2ClientName"     : intentResponseObject.apiClient.name
+            ]
+            break
 
     }
 


### PR DESCRIPTION
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/463
Description: Added international standing order consent PATCH/GET case in the repo consent script to store the debtorAccount in the intent object.