### PR TITLE
524: Verify transport cert used during DCR 

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -1,4 +1,9 @@
 {
+  "properties": {
+    "security": {
+      "allowIgIssuedTestCerts": true
+    }
+  },
   "handler": "_router",
   "heap": [
     {

--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -1,4 +1,9 @@
 {
+  "properties": {
+    "security": {
+      "allowIgIssuedTestCerts": false
+    }
+  },
   "handler": {
     "type": "DispatchHandler",
     "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-as-register.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-as-register.json
@@ -47,7 +47,8 @@
               "comment": "TODO: use env variable",
               "routeArgObJwksHosts": "[\"keystore.openbankingtest.org.uk\"]",
               "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "jwkSetService": "${heap['OBJwkSetService']}",
+              "allowIgIssuedTestCerts": {"$bool": "&{allow.ig.issued.test.certs|false}"}
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-as-register.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-as-register.json
@@ -48,7 +48,7 @@
               "routeArgObJwksHosts": "[\"keystore.openbankingtest.org.uk\"]",
               "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy",
               "jwkSetService": "${heap['OBJwkSetService']}",
-              "allowIgIssuedTestCerts": {"$bool": "&{allow.ig.issued.test.certs|false}"}
+              "allowIgIssuedTestCerts": "${security.allowIgIssuedTestCerts}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-as-register.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-as-register.json
@@ -46,7 +46,8 @@
             "args": {
               "comment": "TODO: use env variable",
               "routeArgObJwksHosts": "[\"keystore.openbankingtest.org.uk\"]",
-              "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy"
+              "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy",
+              "jwkSetService": "${heap['OBJwkSetService']}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
@@ -223,7 +223,6 @@ def certToObject(String certPem) {
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
     Certificate certificate = cf.generateCertificate(certStream);
     def object = [
-      pem: certPem,
       expiryDate: certificate.getNotAfter().toString(),
       subjectDN: certificate.getSubjectDN(),
       subjectDNComponents:  CertificateParserHelper.parseDN(certificate.getSubjectDN().toString()),
@@ -244,6 +243,9 @@ def certToObject(String certPem) {
       roles: CertificateParserHelper.getRoles(certificate,logger),
       publicKey: certificate.getPublicKey(),
     ]
+    logger.debug(SCRIPT_NAME + "Parsed certificate " + object.toString())
+    // Add the X%09Certificate object after the logging of the parsed data to prevent the logs being spammed
+    object.put("certificate", certificate)
 
     return object
 }
@@ -266,8 +268,6 @@ String certPem = URLDecoder.decode(header.firstValue.toString())
 logger.debug(SCRIPT_NAME + "Client certificate PEM: \n" + certPem)
 
 def certObject = certToObject(certPem)
-
-logger.debug(SCRIPT_NAME + "Parsed certificate " + certObject.toString())
 
 // Store certificate details for other filters
 attributes.clientCertificate = certObject

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
@@ -218,9 +218,12 @@ class CertificateParserHelper {
     }
 }
 
-def certToObject(Certificate certificate) {
-
+def certToObject(String certPem) {
+    InputStream certStream = new ByteArrayInputStream(certPem.getBytes());
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    Certificate certificate = cf.generateCertificate(certStream);
     def object = [
+      pem: certPem,
       expiryDate: certificate.getNotAfter().toString(),
       subjectDN: certificate.getSubjectDN(),
       subjectDNComponents:  CertificateParserHelper.parseDN(certificate.getSubjectDN().toString()),
@@ -239,8 +242,7 @@ def certToObject(Certificate certificate) {
       type: certificate.getType(),
       version: certificate.getVersion(),
       roles: CertificateParserHelper.getRoles(certificate,logger),
-      publicKey: certificate.getPublicKey()
-
+      publicKey: certificate.getPublicKey(),
     ]
 
     return object
@@ -263,27 +265,11 @@ String certPem = URLDecoder.decode(header.firstValue.toString())
 
 logger.debug(SCRIPT_NAME + "Client certificate PEM: \n" + certPem)
 
-InputStream certStream = new ByteArrayInputStream(certPem.getBytes());
-
-CertificateFactory cf = CertificateFactory.getInstance("X.509");
-Certificate cert = cf.generateCertificate(certStream);
-
-def certObject = certToObject(cert)
+def certObject = certToObject(certPem)
 
 logger.debug(SCRIPT_NAME + "Parsed certificate " + certObject.toString())
 
 // Store certificate details for other filters
-
 attributes.clientCertificate = certObject
 
 next.handle(context, request)
-
-
-
-
-
-
-
-
-
-

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
@@ -244,7 +244,7 @@ def certToObject(String certPem) {
       publicKey: certificate.getPublicKey(),
     ]
     logger.debug(SCRIPT_NAME + "Parsed certificate " + object.toString())
-    // Add the X%09Certificate object after the logging of the parsed data to prevent the logs being spammed
+    // Add the X509Certificate object after the logging of the parsed data to prevent the logs being spammed
     object.put("certificate", certificate)
 
     return object

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -127,7 +127,7 @@ switch(method.toUpperCase()) {
                 logger.debug("configuration to allowIgIssuedTestCerts is disabled")
                 return(errorResponse(Status.BAD_REQUEST, "software_statement must contain software_jwks_endpoint"));
             }
-            logger.debug(SCRIPT_NAME + "Using jwks")
+            logger.debug(SCRIPT_NAME + "Using jwks from software_statement")
             oidcRegistration.setClaim("jwks",  apiClientOrgJwks )
         }
         else {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -190,7 +190,7 @@ switch(method.toUpperCase()) {
             for (JWK jwk : jwkSet.getJWKsAsList()) {
                 final List<String> x509Chain = jwk.getX509Chain();
                 final String jwkCert = x509Chain.get(0);
-                if ("tls".equals(jwk.getUse()) && Objects.equals(clientCertPem, jwkCert)) {
+                if ("tls".equals(jwk.getUse()) && clientCertPem.equals(jwkCert)) {
                     logger.debug(SCRIPT_NAME + "Found matching tls cert for provided pem, with kid: " + jwk.getKeyId())
                     found = true
                     break

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -185,9 +185,8 @@ switch(method.toUpperCase()) {
         // Verify that the tls transport cert is registered for the TPP's software statement
         if (apiClientOrgJwksUri != null) {
             logger.debug(SCRIPT_NAME + "Checking cert against remote jwks: " + apiClientOrgJwksUri)
-
             return jwkSetService.getJwkSet(new URL(apiClientOrgJwksUri)).thenAsync(jwkSet -> {
-                return tlsClientCertExistsInJwkSet(jwkSet)
+                return verifyTlsClientCertExistsInJwkSet(jwkSet)
             }).thenCatchAsync(e -> {
                 logger.debug(SCRIPT_NAME + "failed to get jwks due to exception", e)
                 return newResultPromise(errorResponse(Status.BAD_REQUEST, "unable to get jwks from url: " + apiClientOrgJwksUri))
@@ -200,7 +199,7 @@ switch(method.toUpperCase()) {
             }
             logger.debug(SCRIPT_NAME + "Checking cert against ssa software_jwks: " + apiClientOrgJwks)
             def jwkSet = new JWKSet(new JsonValue(apiClientOrgJwks.get("keys")))
-            return tlsClientCertExistsInJwkSet(jwkSet)
+            return verifyTlsClientCertExistsInJwkSet(jwkSet)
         }
     case "DELETE":
        break
@@ -211,7 +210,7 @@ switch(method.toUpperCase()) {
 }
 
 
-private Promise<Response, NeverThrowsException> tlsClientCertExistsInJwkSet(jwkSet) {
+private Promise<Response, NeverThrowsException> verifyTlsClientCertExistsInJwkSet(jwkSet) {
     def tlsClientCert = attributes.clientCertificate.certificate
     // RSAKey.parse produces a JWK, we can then extract the cert from the x5c field
     def tlsClientCertX5c = RSAKey.parse(tlsClientCert).getX509CertChain().get(0).toString()

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -1,3 +1,4 @@
+import org.forgerock.util.promise.*
 import org.forgerock.http.protocol.*
 import org.forgerock.json.jose.*
 import org.forgerock.json.jose.jwk.*
@@ -92,7 +93,6 @@ switch(method.toUpperCase()) {
         )
 
         // Update OIDC registration request
-
         if (apiClientOrgJwksUri) {
             logger.debug(SCRIPT_NAME + "Using jwks uri")
             if (routeArgObJwksHosts) {
@@ -123,6 +123,10 @@ switch(method.toUpperCase()) {
             oidcRegistration.setClaim("jwks_uri", apiClientOrgJwksUri)
         }
         else if (apiClientOrgJwks) {
+            if (!allowIgIssuedTestCerts) {
+                logger.debug("configuration to allowIgIssuedTestCerts is disabled")
+                return(errorResponse(Status.BAD_REQUEST, "software_statement must contain software_jwks_endpoint"));
+            }
             logger.debug(SCRIPT_NAME + "Using jwks")
             oidcRegistration.setClaim("jwks",  apiClientOrgJwks )
         }
@@ -179,27 +183,25 @@ switch(method.toUpperCase()) {
         request.setEntity(regJson)
 
         // Verify that the tls transport cert is registered for the TPP's software statement
-        return jwkSetService.getJwkSet(new URL(apiClientOrgJwksUri)).thenAsync(jwkSet -> {
-            def tlsClientCert = attributes.clientCertificate.certificate
-            // RSAKey.parse produces a JWK, we can then extract the cert from the x5c field
-            def tlsClientCertX5c = RSAKey.parse(tlsClientCert).getX509CertChain().get(0).toString()
+        if (apiClientOrgJwksUri != null) {
+            logger.debug(SCRIPT_NAME + "Checking cert against remote jwks: " + apiClientOrgJwksUri)
 
-            def found = false
-            for (JWK jwk : jwkSet.getJWKsAsList()) {
-                final List<String> x509Chain = jwk.getX509Chain();
-                final String jwkX5c = x509Chain.get(0);
-                if ("tls".equals(jwk.getUse()) && tlsClientCertX5c.equals(jwkX5c)) {
-                    logger.debug(SCRIPT_NAME + "Found matching tls cert for provided pem, with kid: " + jwk.getKeyId() + " x5t#S256: " + jwk.getX509ThumbprintS256())
-                    found = true
-                    break
-                }
+            return jwkSetService.getJwkSet(new URL(apiClientOrgJwksUri)).thenAsync(jwkSet -> {
+                return tlsClientCertExistsInJwkSet(jwkSet)
+            }).thenCatchAsync(e -> {
+                logger.debug(SCRIPT_NAME + "failed to get jwks due to exception", e)
+                return newResultPromise(errorResponse(Status.BAD_REQUEST, "unable to get jwks from url: " + apiClientOrgJwksUri))
+            })
+        } else {
+            // Verify against the software_jwks which is a JWKSet embedded within the software_statement
+            // NOTE: this is only suitable for developer testing purposes
+            if (!allowIgIssuedTestCerts) {
+                return(errorResponse(Status.BAD_REQUEST, "software_statement must contain software_jwks_endpoint"));
             }
-            if (found) {
-                return next.handle(context, request)
-            } else {
-                return newResultPromise(errorResponse(Status.BAD_REQUEST,"tls transport cert does not match any certs registered in software_jwks_endpoint"))
-            }
-        })
+            logger.debug(SCRIPT_NAME + "Checking cert against ssa software_jwks: " + apiClientOrgJwks)
+            def jwkSet = new JWKSet(new JsonValue(apiClientOrgJwks.get("keys")))
+            return tlsClientCertExistsInJwkSet(jwkSet)
+        }
     case "DELETE":
        break
 
@@ -208,11 +210,20 @@ switch(method.toUpperCase()) {
 
 }
 
+
+private Promise<Response, NeverThrowsException> tlsClientCertExistsInJwkSet(jwkSet) {
+    def tlsClientCert = attributes.clientCertificate.certificate
+    // RSAKey.parse produces a JWK, we can then extract the cert from the x5c field
+    def tlsClientCertX5c = RSAKey.parse(tlsClientCert).getX509CertChain().get(0).toString()
+    for (JWK jwk : jwkSet.getJWKsAsList()) {
+        final List<String> x509Chain = jwk.getX509Chain();
+        final String jwkX5c = x509Chain.get(0);
+        if ("tls".equals(jwk.getUse()) && tlsClientCertX5c.equals(jwkX5c)) {
+            logger.debug(SCRIPT_NAME + "Found matching tls cert for provided pem, with kid: " + jwk.getKeyId() + " x5t#S256: " + jwk.getX509ThumbprintS256())
+            return next.handle(context, request)
+        }
+    }
+    return newResultPromise(errorResponse(Status.BAD_REQUEST, "tls transport cert does not match any certs registered in jwks for software statement"))
+}
+
 next.handle(context, request)
-
-
-
-
-
-
-


### PR DESCRIPTION
Verify transport cert used during DCR (dynamic client registration) is mapped to the TPP's software statement

- TLS cert is found in the HTTP header ssl-client-cert in PEM format (set by nginx)
- software_jwks_endpoint property in software statement is used to locate the TPP's JWKSet
- ProcessRegistration script now fetches the JWKSet and checks to see if a TLS cert exists by looking for a JWK with an x5c value which matches the TLS cert used to submit the DCR request
- OBIE spec notes that the x5c will only contain a single item (the client's cert) without any chain, and nginx will only send the cert on without the chain.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/524