### PR TITLE
532: Corrected managed object name

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/GetResourceOwnerIdFromConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/GetResourceOwnerIdFromConsent.groovy
@@ -12,7 +12,7 @@ enum IntentType {
     PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT("PDSOC_", "domesticStandingOrderIntent"),
     PAYMENT_INTERNATIONAL_CONSENT("PIC_", "internationalPaymentIntent"),
     PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT("PISC_", "internationalScheduledPaymentIntent"),
-    PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT("PISOC_", "internationalStandingOrdersIntent"),
+    PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT("PISOC_", "internationalStandingOrderIntent"),
     PAYMENT_FILE_CONSENT("PFC_", "filePaymentIntent"),
     FUNDS_CONFIRMATION_CONSENT("FCC_", "fundsConfirmationIntent"),
     DOMESTIC_VRP_PAYMENT_CONSENT("DVRP_", "domesticVrpPaymentIntent")


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/532
Description: Fixed managed object name constant in GetResourceOwnerIdFromConsent.groovy. Wrong - internationalStandingOrdersIntent. Correct - internationalStandingOrderIntent