### PR TITLE
535: Updating to use new Account Access Intent IDM object structure

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -116,7 +116,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
               "role": "AISP",
               "event": "CREATE"
             }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessAccountConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessAccountConsent.groovy
@@ -1,3 +1,4 @@
+import org.forgerock.http.protocol.*
 import java.text.SimpleDateFormat
 import java.util.UUID
 
@@ -20,24 +21,22 @@ def method = request.method
 switch(method.toUpperCase()) {
 
     case "POST":
-        accountIntentData = request.entity.getJson()
-        def tz = TimeZone.getTimeZone("UTC");
-        def df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        df.setTimeZone(tz);
-        def nowAsISO = df.format(new Date());
-
         def consentId = routeArgConsentIdPrefix + UUID.randomUUID().toString()
+        accountIntentData = request.entity.getJson()
+        processAccountAccessRequestData(consentId, accountIntentData)
 
-        accountIntentData._id = consentId
-        accountIntentData.Data.ConsentId = consentId
-        accountIntentData.Data.Status = "AwaitingAuthorisation";
-        accountIntentData.Data.CreationDateTime = nowAsISO
-        accountIntentData.Data.StatusUpdateDateTime = nowAsISO
-        accountIntentData.apiClient = [ "_ref" : "managed/" + routeArgObjApiClient + "/" +  oauth2ClientId ]
+        // NOTE: creating the intent will eventually move to RS, where OBVersion and OBIntentObjectType can be determined more easily
+        def version = getObApiVersion(request)
+        def idmIntent = [
+                _id: consentId,
+                OBVersion: version,
+                OBIntentObjectType: "OBReadConsentResponse1",
+                OBIntentObject: accountIntentData,
+                apiClient: [ "_ref" : "managed/" + routeArgObjApiClient + "/" +  oauth2ClientId ],
+        ]
 
-        logger.debug(SCRIPT_NAME + "final json [" + accountIntentData + "]")
-        request.setEntity(accountIntentData)
-
+        logger.debug(SCRIPT_NAME + "IDM object json [" + idmIntent + "]")
+        request.setEntity(idmIntent)
         request.uri.path = "/openidm/managed/" + routeArgObjAccountAccessConsent
         request.uri.query = "action=create";
         break
@@ -49,19 +48,54 @@ switch(method.toUpperCase()) {
 
     case "GET":
         def consentId = request.uri.path.substring(request.uri.path.lastIndexOf("/") + 1);
+        // Query IDM for a consent with the matching id, only return the OBIntentObject field
         request.uri.path = "/openidm/managed/" + routeArgObjAccountAccessConsent + "/" + consentId
+        request.uri.query = "_fields=OBIntentObject"
         break
 
     default:
-        logger.debug(SCRIPT_NAME + "Method not supported")
+        logger.debug(SCRIPT_NAME + "Method not supported: " + method)
+        return new Response(Status.METHOD_NOT_ALLOWED);
+}
+return next.handle(context, request).then(this.&extractOBIntentObjectFromIdmResponse)
 
+/**
+ * Responses from IDM will always contain the "OBIntentObject" as a top level field (even if we filter).
+ * We want to send only the contents of the OBIntentObject as the response to the client i.e. a valid Open Banking API response
+ */
+private Response extractOBIntentObjectFromIdmResponse(response) {
+    if (response.status.isSuccessful()) {
+        response.entity = response.entity.getJson().get("OBIntentObject")
+    }
+    return response
 }
 
+private void processAccountAccessRequestData(consentId, accountIntentData) {
+    def tz = TimeZone.getTimeZone("UTC");
+    def df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    df.setTimeZone(tz);
+    def nowAsISO = df.format(new Date())
+    accountIntentData.Data.ConsentId = consentId
+    accountIntentData.Data.Status = "AwaitingAuthorisation";
+    accountIntentData.Data.CreationDateTime = nowAsISO
+    accountIntentData.Data.StatusUpdateDateTime = nowAsISO
+}
 
-next.handle(context, request)
-
-
-
-
-
-
+/**
+ * Extract the Open Banking Api version from the request uri
+ * Example uri: /rs/open-banking/v3.1.10/aisp/account-access-consents
+ */
+private String getObApiVersion(request) {
+    def uri = request.uri.toString()
+    def pathPrefix = "/rs/open-banking/"
+    int prefixEndIndex = uri.indexOf(pathPrefix)
+    if (prefixEndIndex < 0) {
+        throw new IllegalStateException("Failed to determine OB API version from uri: " + uri)
+    }
+    int versionStartIndex = prefixEndIndex + pathPrefix.length()
+    int versionEndIndex = uri.indexOf('/', versionStartIndex)
+    if (versionEndIndex < 0) {
+        throw new IllegalStateException("Failed to determine OB API version from uri: " + uri)
+    }
+    return uri.substring(versionStartIndex, versionEndIndex)
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
@@ -4,9 +4,6 @@ import java.text.SimpleDateFormat
 SCRIPT_NAME = "[RepoConsent] - "
 logger.debug(SCRIPT_NAME + "Running...")
 
-/**
- *  definitions
- */
 def buildPatchRequest(incomingRequest, intentType) {
     def body = [];
 
@@ -251,14 +248,7 @@ enum IntentType {
         return consentObject
     }
 }
-/**
- * End definitions
- */
 
-
-/**
- * start script
- */
 def splitUri = request.uri.path.split("/")
 
 // response object

--- a/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
@@ -7,26 +7,40 @@ logger.debug(SCRIPT_NAME + "Running...")
 /**
  *  definitions
  */
-def buildPatchRequest(incomingRequest) {
+def buildPatchRequest(incomingRequest, intentType) {
     def body = [];
 
     if (incomingRequest.data && incomingRequest.data.Status) {
-        body.push([
-                "operation": "replace",
-                "field"    : "/Data/Status",
-                "value"    : incomingRequest.data.Status
-        ]);
-
         def tz = TimeZone.getTimeZone("UTC");
         def df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         df.setTimeZone(tz);
         def nowAsISO = df.format(new Date());
 
-        body.push([
-                "operation": "replace",
-                "field"    : "/Data/StatusUpdateDateTime",
-                "value"    : nowAsISO
-        ]);
+        // Account Access Intent structure has been updated, therefore different logic is required.
+        if (intentType == IntentType.ACCOUNT_ACCESS_CONSENT) {
+            logger.debug(SCRIPT_NAME + "Patching account access consent: " + incomingRequest.data.Status)
+            body.push([
+                    "operation": "replace",
+                    "field"    : "OBIntentObject/Data/Status",
+                    "value"    : incomingRequest.data.Status
+            ]);
+            body.push([
+                    "operation": "replace",
+                    "field"    : "OBIntentObject/Data/StatusUpdateDateTime",
+                    "value"    : nowAsISO
+            ]);
+        } else {
+            body.push([
+                    "operation": "replace",
+                    "field"    : "/Data/Status",
+                    "value"    : incomingRequest.data.Status
+            ]);
+            body.push([
+                    "operation": "replace",
+                    "field"    : "/Data/StatusUpdateDateTime",
+                    "value"    : nowAsISO
+            ]);
+        }
     }
 
     if (incomingRequest.resourceOwnerUsername) {
@@ -105,11 +119,11 @@ def convertIDMResponse(intentResponseObject, intentType) {
         case IntentType.ACCOUNT_ACCESS_CONSENT:
             responseObj = [
                     "id"                   : intentResponseObject._id,
-                    "data"                 : intentResponseObject.Data,
+                    "data"                 : intentResponseObject.OBIntentObject.Data,
                     // RS expect 'Data' instead 'data' to deserialize the json to OB object
                     // TODO make it compatible with RS, until fixed on https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/522
                     // It's a duplication only to be compatible temporary, when the issue has been fixed delete 'data' and 'Data'
-                    "Data"                 : intentResponseObject.Data,
+                    "Data"                 : intentResponseObject.OBIntentObject.Data,
                     "accountIds"           : intentResponseObject.accounts,
                     "resourceOwnerUsername": intentResponseObject.user ? intentResponseObject.user._id : null,
                     "oauth2ClientId"       : intentResponseObject.apiClient.oauth2ClientId,
@@ -274,7 +288,12 @@ if(intentType){
     return response
 }
 
-def requestUri = routeArgIdmBaseUri + "/openidm/managed/" + intentObject + "/" + intentId + "?_fields=_id,Data,user/_id,accounts,account,apiClient/oauth2ClientId,apiClient/name";
+def requestUri = null
+if (intentType == IntentType.ACCOUNT_ACCESS_CONSENT) {
+    requestUri = routeArgIdmBaseUri + "/openidm/managed/" + intentObject + "/" + intentId + "?_fields=_id,OBIntentObject,user/_id,accounts,account,apiClient/oauth2ClientId,apiClient/name";
+} else {
+    requestUri = routeArgIdmBaseUri + "/openidm/managed/" + intentObject + "/" + intentId + "?_fields=_id,Data,user/_id,accounts,account,apiClient/oauth2ClientId,apiClient/name";
+}
 
 if (request.getMethod() == "GET") {
     Request intentRequest = new Request();
@@ -298,7 +317,7 @@ if (request.getMethod() == "GET") {
         def intentResponseObject = intentResponseContent.getJson();
 
         if(intentResponseObject.apiClient == null){
-            message = "Orfan consent, The consent requested to get with id [" + intentResponseObject._id + "] doesn't have a apiClient related."
+            message = "Orphan consent, The consent requested to get with id [" + intentResponseObject._id + "] doesn't have a apiClient related."
             logger.error(SCRIPT_NAME + message)
             response.status = Status.BAD_REQUEST
             response.entity = "{ \"error\":\"" + message + "\"}"
@@ -319,7 +338,7 @@ if (request.getMethod() == "GET") {
     patchRequest.setMethod('POST');
     patchRequest.setUri(requestUri + "&_action=patch");
     patchRequest.getHeaders().add("Content-Type", "application/json");
-    patchRequest.setEntity(JsonOutput.toJson(buildPatchRequest(request.getEntity().getJson())))
+    patchRequest.setEntity(JsonOutput.toJson(buildPatchRequest(request.getEntity().getJson(), intentType)))
 
     http.send(patchRequest).then(patchResponse -> {
         patchRequest.close()
@@ -341,7 +360,7 @@ if (request.getMethod() == "GET") {
         def patchResponseObject = patchResponseContent.getJson();
 
         if(patchResponseObject.apiClient == null){
-            message = "Orfan consent, The consent requested to patch doesn't have an apiClient related."
+            message = "Orphan consent, The consent requested to patch doesn't have an apiClient related."
             logger.error(SCRIPT_NAME + message)
             response.status = Status.BAD_REQUEST
             response.entity = "{ \"error\":\"" + message + "\"}"


### PR DESCRIPTION
- Updating ProcessAccountConsent.groovy to create IDM objects with the new structure
- Updating RepoConsent.groovy to query/patch the new structure, note that this script is shared by all intent types so logic has been added to only use the new structure for Account Access Intents. Eventually all intent types will be updated to the new structure

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/535