### PR TITLE
Adding frequency validation for international standing orders

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -152,6 +152,15 @@
           }
         },
         {
+          "comment": "Check Frequency parameter in domestic standing order payload",
+          "name": "CheckFrequencyValue",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "CheckFrequencyValue.groovy"
+          }
+        },
+        {
           "comment": "Prepare request for IDM",
           "name": "ProcessPaymentConsent",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -146,6 +146,15 @@
           }
         },
         {
+          "comment": "Check Frequency parameter in domestic standing order payload",
+          "name": "CheckFrequencyValue",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "CheckFrequencyValue.groovy"
+          }
+        },
+        {
           "comment": "Adjust URL for downstream resource server",
           "type": "UriPathRewriteFilter",
           "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -1,6 +1,6 @@
 {
   "comment": "Handle Open Banking International Standing Orders request",
-  "name": "42 - Open Banking International Standing Orders Access",
+  "name": "57 - Open Banking International Standing Orders Access",
   "auditService": "AuditService-OB-Route",
   "baseURI": "https://&{rs.fqdn}",
   "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/pisp/international-standing-orders')}",


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/546
Description: Adding frequency validation to consent and submit routes for international standing orders. This missing validation is causing some functional tests to fail and it's mandatory to implement before merging the functional tests.