### PR TITLE
537: Fixing a bug in the delete account consent flow

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessAccountConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessAccountConsent.groovy
@@ -44,7 +44,13 @@ switch(method.toUpperCase()) {
     case "DELETE":
         def consentId = request.uri.path.substring(request.uri.path.lastIndexOf("/") + 1);
         request.uri.path = "/openidm/managed/" + routeArgObjAccountAccessConsent + "/" + consentId
-        break
+        return next.handle(context, request).then(response -> {
+            if (response.status.isSuccessful()) {
+                // OB spec expects HTTP 204 No Content response
+                return new Response(Status.NO_CONTENT)
+            }
+            return response
+        })
 
     case "GET":
         def consentId = request.uri.path.substring(request.uri.path.lastIndexOf("/") + 1);


### PR DESCRIPTION
Currently HTTP 200 is returned when deleting an account access consent, with the consent json being sent in the response body.

Fixing this as per the OB spec to return HTTP 204 No Content.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/537