### PR TITLE
576: Improving test CaffeineCacheTest.shouldEvictEntriesBasedOnTime

### DIFF
--- a/securebanking-openbanking-uk-gateway-jwks/src/test/java/com/forgerock/securebanking/uk/gateway/jwks/cache/caffeine/CaffeineCacheTest.java
+++ b/securebanking-openbanking-uk-gateway-jwks/src/test/java/com/forgerock/securebanking/uk/gateway/jwks/cache/caffeine/CaffeineCacheTest.java
@@ -68,13 +68,16 @@ class CaffeineCacheTest {
     @Test
     void shouldEvictEntriesBasedOnTime() {
         final int maxSize = 100;
-        final Duration expiryDuration = Duration.ofMillis(10L);
+        final Duration expiryDuration = Duration.ofMillis(100L);
         final CaffeineCache<String, String> cache = createCache(maxSize, expiryDuration);
         for (int i = 0; i < maxSize; i++) {
             cache.put("key" + i, "value" + i);
         }
         final Cache<String, String> underlyingCache = getUnderlyingCache(cache);
-        assertEquals(maxSize, underlyingCache.estimatedSize());
+        org.assertj.core.api.Assertions.assertThat(underlyingCache.estimatedSize())
+                                       .as("Cache entries at start of test")
+                                       .isGreaterThan(0);
+
 
         LockSupport.parkNanos(expiryDuration.toNanos());
         // Attempt to get something from the cache, which will trigger the eviction


### PR DESCRIPTION
The test works when run locally, but we have noticed failures when run via a GitHub action. The failures appear to be due to the test taking longer than expected to add the items to the cache, which means that some have been evicted before expected.

Fixing by increasing the expiryDuration and doing a sanity test that the cache has items (rather than checking for an exact number)

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/576