### PR TITLE
597: Fixing GET/PUT/DELETE routes for DCR

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -1,6 +1,6 @@
 {
-  "comment": "TPP dynamic registration",
-  "name": "03 - Open Banking Register TPP",
+  "comment": "Create new TPP dynamic client registration",
+  "name": "03 - Open Banking DCR - Dynamic Client Registration",
   "auditService": "AuditService-OB-Route",
   "baseURI": "https://&{identity.platform.fqdn}",
   "condition": "${matches(request.uri.path, '^/am/oauth2/realms/root/realms/&{am.realm}/register')}",
@@ -96,22 +96,29 @@
           }
         },
         {
-          "comment": "Fetch access token for dynamic client registration",
-          "type": "ClientCredentialsOAuth2ClientFilter",
+          "name": "AddIgAccessTokenForNewRegistrations",
+          "comment": "When creating a new registration we need to obtain credentials to allow IG to talk to AM. For flows which operate on an existing registration, the TPP must supply the registration_access_token returned in the DCR response",
+          "type": "ConditionalFilter",
           "config": {
-            "clientId": "&{ig.client.id}",
-            "clientSecretId": "ig.client.secret",
-            "secretsProvider": "SystemAndEnvSecretStore-IAM",
-            "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
-            "scopes": [
-              "dynamic_client_registration fr:idm:*"
-            ],
-            "handler": "TokenRequestHandler"
+            "condition": "${request.method == 'POST'}",
+            "delegate": {
+              "comment": "Fetch access token for dynamic client registration - IG credentials to talk to AM",
+              "type": "ClientCredentialsOAuth2ClientFilter",
+              "config": {
+                "clientId": "&{ig.client.id}",
+                "clientSecretId": "ig.client.secret",
+                "secretsProvider": "SystemAndEnvSecretStore-IAM",
+                "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
+                "scopes": [
+                  "dynamic_client_registration fr:idm:*"
+                ],
+                "handler": "TokenRequestHandler"
+              }
+            }
           }
         }
       ],
       "handler": "ReverseProxyHandler"
-      }
-
+    }
   }
 }


### PR DESCRIPTION
- Operating on an existing registration requires the uri to be rewritten to conform to the AM api (passing client_id as a query param rather than in the path)
- Using a ConditionalFilter to only add the IG Access token for POST requests (registering a new client), the GET/PUT/DELETE  calls needs to supply their own access token (which was returned in the registration_access_token field of the DCR response)
- Renaming route to 03-ob-dcr-register-tpp.json

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/597