### PR TITLE
597: Fixing bug where idm apiClient is being deleted even if the AM delete is rejected

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -169,7 +169,7 @@ switch(method.toUpperCase()) {
     });
     break
   case "DELETE":
-    return next.handle(context, request).thenOnResult(response -> {
+    return next.handle(context, request).thenAsync(response -> {
       if (response.status.isSuccessful()) {
         // ProcessRegistration filter will have added the client_id param
         def apiClientId = request.getQueryParams().getFirst("client_id")
@@ -177,11 +177,12 @@ switch(method.toUpperCase()) {
         deleteApiClientReq.setMethod('DELETE')
         deleteApiClientReq.setUri(routeArgIdmBaseUri + "/openidm/managed/" + routeArgObjApiClient + "/" + apiClientId)
         logger.info("Deleting IDM object: " + routeArgObjApiClient + " for client_id: " + apiClientId)
-        return http.send(deleteApiClientReq).thenOnResult(idmResponse -> {
+        return http.send(deleteApiClientReq).thenAsync(idmResponse -> {
           if (idmResponse.status.isSuccessful()) {
-            return new Response(Status.NO_CONTENT)
+            logger.debug("IDM object successfully deleted for client_id: " + apiClientId)
+            return newResultPromise(new Response(Status.NO_CONTENT))
           }
-          return (errorResponse(Status.BAD_REQUEST, "Failed to delete registration"));
+          return newResultPromise(errorResponse(Status.BAD_REQUEST, "Failed to delete registration"))
         })
       }
       return response

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -184,6 +184,7 @@ switch(method.toUpperCase()) {
           return (errorResponse(Status.BAD_REQUEST, "Failed to delete registration"));
         })
       }
+      return response
     })
   default:
     logger.debug(SCRIPT_NAME + "Method not supported")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -2,6 +2,7 @@ import org.forgerock.json.jose.jws.SigningManager;
 import org.forgerock.json.jose.jwk.JWKSet;
 import org.forgerock.http.protocol.Status;
 import java.net.URI;
+import static org.forgerock.util.promise.Promises.newResultPromise
 
 SCRIPT_NAME = "[SSAVerifier] - "
 logger.debug(SCRIPT_NAME + "Running...")
@@ -62,6 +63,7 @@ def method = request.method
 switch(method.toUpperCase()) {
 
     case "POST":
+    case "PUT":
 
     if (!attributes.registrationJWTs) {
         return(errorResponse(Status.UNAUTHORIZED,"No registration JWT"));
@@ -110,8 +112,7 @@ switch(method.toUpperCase()) {
     // jwksRequest.getHeaders().add("Host",ssaJwksUri.getHost());
 
 
-    http.send(jwksRequest).then(jwksResponse -> {
-
+    return http.send(jwksRequest).thenAsync(jwksResponse -> {
       jwksRequest.close();
       logger.debug(SCRIPT_NAME + "Back from JWKS URI");
       def jwksResponseContent = jwksResponse.getEntity().getString();
@@ -121,30 +122,18 @@ switch(method.toUpperCase()) {
       logger.debug(SCRIPT_NAME + "entity " + jwksResponseContent);
 
       if (jwksResponseStatus != Status.OK) {
-          return(errorResponse(Status.UNAUTHORIZED,"Bad response from JWKS URI " + jwksResponseStatus));
+          return newResultPromise(errorResponse(Status.UNAUTHORIZED,"Bad response from JWKS URI " + jwksResponseStatus))
       }
       else if (!verifySignature(ssaJwt,jwksResponseContent)) {
-          return(errorResponse(Status.UNAUTHORIZED,"Signature not verified"));
+          return newResultPromise(errorResponse(Status.UNAUTHORIZED,"Signature not verified"))
       }
-
-      return null;
-    }).thenAsync (error -> {
-      if (error) {
-          // TODO: This doesn't work - get cast error from Response to Promise
-          logger.error(SCRIPT_NAME + "Sending back error response");
-          return error;
-      }
-      next.handle(context, request);
-    });
-    break
+      return next.handle(context, request)
+    })
 
     case "DELETE":
-       break
+    case "GET":
+        return next.handle(context, request)
     default:
         logger.debug(SCRIPT_NAME + "Method not supported")
-
+        return errorResponse(Status.METHOD_NOT_ALLOWED,"Method Not Allowed")
 }
-
-
-next.handle(context, request)
-


### PR DESCRIPTION
CreateApiClient filter runs after the response from the ReverseProxyHandler that talks to AM. The apiClient must only be deleted if the AM response is successful i.e. AM delete the OAuth2 client

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/597