### PR TITLE
618 Fixing SSAVerifier to only call next.handle once 

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -135,5 +135,5 @@ switch(method.toUpperCase()) {
         return next.handle(context, request)
     default:
         logger.debug(SCRIPT_NAME + "Method not supported")
-        return(errorResponse(Status.METHOD_NOT_ALLOWED,"Method Not Allowed"))
+        return errorResponse(Status.METHOD_NOT_ALLOWED,"Method Not Allowed")
 }


### PR DESCRIPTION
Fixing a bug where the next.handle is called from the request handling thread and also from the jwksResponse async block. This results in 2 calls being made to AM, which causes 2 clients to be created.

The updated logic is as follows:
- For requests to create/update a DCR we need to validate the SSA, which needs to make an async request to the JWKS (and then verify the sig), if this is successful then the request can continue to the next handler.

- For get/delete, nothing needs to be done in the SSAVerifier, the request is passed directly to the next handler