### PR TITLE
623: Handles missing subject_type

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -157,6 +157,11 @@ switch(method.toUpperCase()) {
         oidcRegistration.setClaim("client_name",apiClientOrgName)
         oidcRegistration.setClaim("tls_client_certificate_bound_access_tokens", true)
 
+        def subject_type = oidcRegistration.getClaim("subject_type", String.class);
+        if(!subject_type){
+            oidcRegistration.setClaim("subject_type", "pairwise");
+        }
+
         // Sanity check on scopes
 
         def scopes = oidcRegistration.getClaim("scope")


### PR DESCRIPTION
If the subject_type is missing then we need to set the subject_type to "pairwise" otherwise it will be set by default to "public"

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/623