### PR TITLE
621: Fixing DCR API to return software_statement in POST/PUT/GET responses

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -38,6 +38,7 @@ switch(method.toUpperCase()) {
       }
 
       def oauth2ClientId = clientData.client_id;
+
       def ssaJwt = attributes.registrationJWTs.ssaJwt;
       if (!ssaJwt) {
         return (errorResponse(Status.UNAUTHORIZED, "No SSA JWT"));
@@ -65,7 +66,7 @@ switch(method.toUpperCase()) {
               "id"            : ssaSoftwareId,
               "name"          : ssaSoftwareName,
               "description"   : ssaSoftwareDescription,
-              "ssa"           : ssaJwt,
+              "ssa"           : attributes.registrationJWTs.ssaStr,
               "logoUri"       : ssaLogoUri,
               "oauth2ClientId": oauth2ClientId,
               "apiClientOrg"  : [ "_ref" : "managed/" + routeArgObjApiClientOrg + "/" +  organizationIdentifier ]

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -207,12 +207,19 @@ switch(method.toUpperCase()) {
         // Verify that the tls transport cert is registered for the TPP's software statement
         if (apiClientOrgJwksUri != null) {
             logger.debug(SCRIPT_NAME + "Checking cert against remote jwks: " + apiClientOrgJwksUri)
-            return jwkSetService.getJwkSet(new URL(apiClientOrgJwksUri)).thenAsync(jwkSet -> {
-                return verifyTlsClientCertExistsInJwkSet(jwkSet)
-            }).thenCatchAsync(e -> {
-                logger.debug(SCRIPT_NAME + "failed to get jwks due to exception", e)
-                return newResultPromise(errorResponse(Status.BAD_REQUEST, "unable to get jwks from url: " + apiClientOrgJwksUri))
-            })
+            return jwkSetService.getJwkSet(new URL(apiClientOrgJwksUri))
+                                .thenCatchAsync(e -> {
+                                    logger.debug(SCRIPT_NAME + "failed to get jwks due to exception", e)
+                                    return newResultPromise(errorResponse(Status.BAD_REQUEST, "unable to get jwks from url: " + apiClientOrgJwksUri))
+                                })
+                                .thenAsync(jwtSet -> {
+                                    if (!tlsClientCertExistsInJwkSet(jwtSet)) {
+                                        return newResultPromise(errorResponse(Status.BAD_REQUEST, "tls transport cert does not match any certs registered in jwks for software statement"))
+                                    }
+                                    return next.handle(context, request)
+                                               .thenOnResult(response -> addSoftwareStatementToResponse(response, ssa))
+                                })
+
         } else {
             // Verify against the software_jwks which is a JWKSet embedded within the software_statement
             // NOTE: this is only suitable for developer testing purposes
@@ -221,16 +228,28 @@ switch(method.toUpperCase()) {
             }
             logger.debug(SCRIPT_NAME + "Checking cert against ssa software_jwks: " + apiClientOrgJwks)
             def jwkSet = new JWKSet(new JsonValue(apiClientOrgJwks.get("keys")))
-            return verifyTlsClientCertExistsInJwkSet(jwkSet)
+            if (!tlsClientCertExistsInJwkSet(jwtSet)) {
+                return newResultPromise(errorResponse(Status.BAD_REQUEST, "tls transport cert does not match any certs registered in jwks for software statement"))
+            }
+            return next.handle(context, request)
+                       .thenOnResult(response -> addSoftwareStatementToResponse(response, ssa))
         }
 
     case "DELETE":
+        rewriteUriToAccessExistingAmRegistration()
+        return next.handle(context, request)
     case "GET":
         rewriteUriToAccessExistingAmRegistration()
-        break
-
+        return next.handle(context, request)
+                   .thenOnResult(response -> {
+                       var apiClient = attributes.apiClient
+                       if (apiClient && apiClient.ssa) {
+                           addSoftwareStatementToResponse(response, apiClient.ssa)
+                       }
+                   })
     default:
         logger.debug(SCRIPT_NAME + "Method not supported")
+        return next.handle(context, request)
 
 }
 
@@ -244,13 +263,21 @@ switch(method.toUpperCase()) {
 private void rewriteUriToAccessExistingAmRegistration() {
     def path = request.uri.path
     def lastSlashIndex = path.lastIndexOf("/")
-    def apiClientId = path.substring(lastSlashIndex + 1);
+    def apiClientId = path.substring(lastSlashIndex + 1)
     request.uri.setRawPath(path.substring(0, lastSlashIndex))
     request.uri.setRawQuery("client_id=" + apiClientId)
 }
 
+private void addSoftwareStatementToResponse(response, ssa) {
+    logger.debug("Adding software_statement: " + ssa)
+    var registrationResponse = response.getEntity().getJson()
+    if (!registrationResponse["software_statement"]) {
+        registrationResponse["software_statement"] = ssa
+    }
+    response.entity.setJson(registrationResponse)
+}
 
-private Promise<Response, NeverThrowsException> verifyTlsClientCertExistsInJwkSet(jwkSet) {
+private boolean tlsClientCertExistsInJwkSet(jwkSet) {
     def tlsClientCert = attributes.clientCertificate.certificate
     // RSAKey.parse produces a JWK, we can then extract the cert from the x5c field
     def tlsClientCertX5c = RSAKey.parse(tlsClientCert).getX509CertChain().get(0).toString()
@@ -259,10 +286,9 @@ private Promise<Response, NeverThrowsException> verifyTlsClientCertExistsInJwkSe
         final String jwkX5c = x509Chain.get(0);
         if ("tls".equals(jwk.getUse()) && tlsClientCertX5c.equals(jwkX5c)) {
             logger.debug(SCRIPT_NAME + "Found matching tls cert for provided pem, with kid: " + jwk.getKeyId() + " x5t#S256: " + jwk.getX509ThumbprintS256())
-            return next.handle(context, request)
+            return true
         }
     }
-    return newResultPromise(errorResponse(Status.BAD_REQUEST, "tls transport cert does not match any certs registered in jwks for software statement"))
+    logger.debug(SCRIPT_NAME + "tls transport cert does not match any certs registered in jwks for software statement")
+    return false
 }
-
-next.handle(context, request)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -148,6 +148,7 @@ switch(method.toUpperCase()) {
         // Store SSA and registration JWT for signature check
 
         attributes.registrationJWTs = [
+                "ssaStr": ssa,
                 "ssaJwt" : ssaJwt,
                 "registrationJwt": regJwt,
                 "registrationJwksUri": apiClientOrgJwksUri,

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -269,7 +269,6 @@ private void rewriteUriToAccessExistingAmRegistration() {
 }
 
 private void addSoftwareStatementToResponse(response, ssa) {
-    logger.debug("Adding software_statement: " + ssa)
     var registrationResponse = response.getEntity().getJson()
     if (!registrationResponse["software_statement"]) {
         registrationResponse["software_statement"] = ssa


### PR DESCRIPTION
For GET requests, the ssa needs to be looked up from IDM.

Fixed a bug which meant that the IDM apiClient.ssa field was set to null. This was due to the trying to set the field based on the response from AM. We do not pass the ssa (software_statement) field to AM, therefore it is not in the response.

For POST & PUT requests, the ssa from the request is added to the response from AM.

DELETE returns no content.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/621