### PR TITLE
570: Configure sbat namespaces to use correct FR Platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.jar
 *.zip
 staging/
 tmp/

--- a/kustomize/overlay/7.1.0/securebanking/andra-racovita/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/andra-racovita/configmap.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: securebanking-platform-config
-data:
-  IG_FQDN: obdemo.andra-racovita.forgerock.financial
-  RS_FQDN: rs.andra-racovita.forgerock.financial
-  RCS_FQDN: rcs.andra-racovita.forgerock.financial
-  

--- a/kustomize/overlay/7.1.0/securebanking/andra-racovita/kustomization.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/andra-racovita/kustomization.yaml
@@ -1,8 +1,0 @@
-namespace: andra-racovita
-commonLabels:
-  app.kubernetes.io/name: "forgerock"
-resources:
-- ../defaults
-
-patchesStrategicMerge:
-  - configmap.yaml

--- a/kustomize/overlay/7.1.0/securebanking/christian-brindley/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/christian-brindley/configmap.yaml
@@ -6,4 +6,5 @@ data:
   IG_FQDN: obdemo.christian-brindley.forgerock.financial
   RS_FQDN: rs.christian-brindley.forgerock.financial
   RCS_FQDN: rcs.christian-brindley.forgerock.financial
+  RCS_UI_FQDN: rcs-ui.christian-brindley.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.christian-brindley.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/dev/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/dev/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: securebanking-platform-config
+data:
+  IG_FQDN: obdemo.dev.forgerock.financial
+  RS_FQDN: rs.dev.forgerock.financial
+  RCS_FQDN: rcs.dev.forgerock.financial
+  RCS_UI_FQDN: rcs-ui.dev.forgerock.financial
+  IDENTITY_PLATFORM_FQDN: iam.dev.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/frlaura-jianu/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/frlaura-jianu/configmap.yaml
@@ -6,3 +6,5 @@ data:
   IG_FQDN: obdemo.frlaura-jianu.forgerock.financial
   RS_FQDN: rs.frlaura-jianu.forgerock.financial
   RCS_FQDN: rcs.frlaura-jianu.forgerock.financial
+  RCS_UI_FQDN: rcs-ui.frlaura-jianu.forgerock.financial
+  IDENTITY_PLATFORM_FQDN: iam.frlaura-jianu.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/jorgesanchezperez/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/jorgesanchezperez/configmap.yaml
@@ -6,3 +6,5 @@ data:
   IG_FQDN: obdemo.jorgesanchezperez.forgerock.financial
   RS_FQDN: rs.jorgesanchezperez.forgerock.financial
   RCS_FQDN: rcs.jorgesanchezperez.forgerock.financial
+  RCS_UI_FQDN: rcs-ui.jorgesanchezperez.forgerock.financial
+  IDENTITY_PLATFORM_FQDN: iam.jorgesanchezperez.forgerock.financial  

--- a/kustomize/overlay/7.1.0/securebanking/mariantiris/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/mariantiris/configmap.yaml
@@ -6,3 +6,5 @@ data:
   IG_FQDN: obdemo.mariantiris.forgerock.financial
   RS_FQDN: rs.mariantiris.forgerock.financial
   RCS_FQDN: rcs.mariantiris.forgerock.financial
+  RCS_UI_FQDN: rcs-ui.mariantiris.forgerock.financial
+  IDENTITY_PLATFORM_FQDN: iam.mariantiris.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/nightly/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/nightly/configmap.yaml
@@ -5,8 +5,8 @@ metadata:
 data:
   ENVIRONMENT_TYPE: FIDC
   IG_FQDN: obdemo.nightly.forgerock.financial
-  IDENTITY_PLATFORM_FQDN: openam-forgerock-securebankingaccelerato.forgeblocks.com
   RS_FQDN: rs.nightly.forgerock.financial
   RCS_FQDN: rcs.nightly.forgerock.financial
   RCS_UI_FQDN: rcs-ui.nightly.forgerock.financial
+  IDENTITY_PLATFORM_FQDN: openam-forgerock-securebankingaccelerato.forgeblocks.com
   USER_OBJECT: alpha_user


### PR DESCRIPTION
Change kustomize overlays to make each developer's sbat env point at their own CDK. This kustomize overlay is used to create a config map that contains the settings by the SBAT elements to communicate with a CDK. 

Nightly will point at the FIdC instance.

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/570