### PR TITLE
Update AddDetachedSig.groovy

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/AddDetachedSig.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/AddDetachedSig.groovy
@@ -36,7 +36,13 @@ next.handle(context, request).thenOnResult({ response ->
     signingManager.newSigningHandler(purpose).then({ signingHandler ->
         logger.debug(SCRIPT_NAME + "Building of the JWT started")
 
-        JwtClaimsSet jwtClaimsSet = new JwtClaimsSet(response.getEntity().getJson())
+        JwtClaimsSet jwtClaimsSet
+        // We get content empty on submit file payment API
+        if (response.getEntity().isRawContentEmpty()) {
+            jwtClaimsSet = new JwtClaimsSet()
+        } else {
+            jwtClaimsSet = new JwtClaimsSet(response.getEntity().getJson())
+        }
         logger.debug(SCRIPT_NAME + "jwtClaimsSet: " + jwtClaimsSet)
 
         List<String> critClaims = new ArrayList<String>();


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/660

Added an additional check for empty payload on response signing. An empty JwtClaimsSet object is initialised in the case of empty response payload, which allows us to create empty reponse signature as required by the spec in the case of the submit file API **POST /file-payment-consents/{ConsentId}/file**