### PR TITLE
257: Propagate x-fapi-interaction-id through the system

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -69,11 +69,55 @@
       "name" : "ForgeRockClientHandler",
       "type" : "Chain",
       "config" : {
-        "filters" : [ "TransactionIdOutboundFilter" ],
+        "filters" : [ 
+          {
+            "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+            "name": "FapiInteractionIdFilter",
+            "type": "FapiInteractionIdFilter"
+          },
+          {
+            "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext",
+            "name": "FapiTransactionIdFilter-1",
+            "type": "ScriptableFilter",
+            "config": {
+              "type": "application/x-groovy",
+              "file": "FapiTransactionIdFilter.groovy"
+            }
+          },
+          "TransactionIdOutboundFilter"
+       ],
         "handler" : "ClientHandler"
       },
       "capture" : [ "response", "request" ]
     },
+    {
+      "name": "SBATReverseProxyHandler",
+      "type": "Chain",
+      "capture": [
+        "request",
+        "response"
+      ],
+      "config": {
+        "filters" : [ 
+          {
+            "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+            "name": "FapiInteractionIdFilter",
+            "type": "FapiInteractionIdFilter"
+          },
+          {
+            "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext",
+            "name": "FapiTransactionIdFilter-1",
+            "type": "ScriptableFilter",
+            "config": {
+              "type": "application/x-groovy",
+              "file": "FapiTransactionIdFilter.groovy"
+            }
+          },
+          "TransactionIdOutboundFilter"
+       ],
+        "handler" : "ReverseProxyHandler"
+      }
+    },    
     {
       "name" : "AmService-OBIE",
       "type" : "AmService",

--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -79,6 +79,7 @@
     {
       "name": "SBATFapiInteractionFilterChain",
       "type": "ChainOfFilters",
+      "comment": "This filter chain will set the x-fapi-interaction-id (if not provided in the request), and also set the transaction context to the x-fapi-interaction-id value. This means that if the 'TransactionIdOutboundFilter' is specified on any handlers used by the chain the x-fapi-interaction-id value will be passed onward in the X-ForgeRock-TransactionId header",
       "config" : {
         "filters": [
           {

--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -70,6 +70,17 @@
       "type" : "Chain",
       "config" : {
         "filters" : [ 
+          "TransactionIdOutboundFilter"
+       ],
+        "handler" : "ClientHandler"
+      },
+      "capture" : [ "response", "request" ]
+    },
+    {
+      "name": "SBATFapiInteractionFilterChain",
+      "type": "ChainOfFilters",
+      "config" : {
+        "filters": [
           {
             "comment": "Add x-fapi-interaction-id header if one was not present in the request",
             "name": "FapiInteractionIdFilter",
@@ -83,12 +94,9 @@
               "type": "application/x-groovy",
               "file": "FapiTransactionIdFilter.groovy"
             }
-          },
-          "TransactionIdOutboundFilter"
-       ],
-        "handler" : "ClientHandler"
-      },
-      "capture" : [ "response", "request" ]
+          }
+        ]
+      }
     },
     {
       "name": "SBATReverseProxyHandler",
@@ -99,20 +107,6 @@
       ],
       "config": {
         "filters" : [ 
-          {
-            "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-            "name": "FapiInteractionIdFilter",
-            "type": "FapiInteractionIdFilter"
-          },
-          {
-            "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext",
-            "name": "FapiTransactionIdFilter-1",
-            "type": "ScriptableFilter",
-            "config": {
-              "type": "application/x-groovy",
-              "file": "FapiTransactionIdFilter.groovy"
-            }
-          },
           "TransactionIdOutboundFilter"
        ],
         "handler" : "ReverseProxyHandler"

--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -80,7 +80,7 @@
       "config" : {
         "url" : "https://&{identity.platform.fqdn}/am",
         "realm" : "/&{am.realm}",
-        "version" : "6.5.1",
+        "version" : "7.2.0",
         "agent" : {
           "username" : "ig-agent",
           "passwordSecretId" : "ig.agent.password"

--- a/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
@@ -1,13 +1,18 @@
 {
   "comment": "Return Open Banking endpoints supported by Resource Server",
-  "name" : "01 - Open Banking RS Metadata",
+  "name": "01 - Open Banking RS Metadata",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "https://&{rs.fqdn}",
-  "condition" : "${matches(request.uri.path, '^/rs/open-banking/discovery')}",
+  "baseURI": "https://&{rs.fqdn}",
+  "condition": "${matches(request.uri.path, '^/rs/open-banking/discovery')}",
   "handler": {
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Adjust inbound URL to resource server base URL",
           "name": "UriPathRewriteFilter-RS",
@@ -56,11 +61,11 @@
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file" : "ProcessRs.groovy"
+            "file": "ProcessRs.groovy"
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
@@ -61,7 +61,7 @@
           }
         }
       ],
-      "handler": "ForgeRockClientHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
@@ -8,11 +8,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Adjust inbound URL to resource server base URL",
           "name": "UriPathRewriteFilter-RS",
@@ -65,7 +61,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandler"
+      "handler": "ForgeRockClientHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
@@ -9,20 +9,6 @@
     "config": {
       "filters": [
         {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
-        {
-          "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext",
-          "name": "FapiTransactionIdFilter-1",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "FapiTransactionIdFilter.groovy"
-          }
-        },
-        {
           "comment": "Set downstream Host header",
           "name" : "HeaderFilter-ChangeHostToIAM",
           "type" : "HeaderFilter",
@@ -47,9 +33,8 @@
             }
           }
         }
-
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 } 

--- a/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
@@ -8,6 +8,7 @@
     "type": "Chain",
     "config": {
       "filters": [
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Set downstream Host header",
           "name" : "HeaderFilter-ChangeHostToIAM",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
@@ -9,6 +9,20 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
+          "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext",
+          "name": "FapiTransactionIdFilter-1",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "FapiTransactionIdFilter.groovy"
+          }
+        },
+        {
           "comment": "Set downstream Host header",
           "name" : "HeaderFilter-ChangeHostToIAM",
           "type" : "HeaderFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -8,11 +8,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Enforce response content type as application/json",
           "name": "HeaderFilter-AddResponseHeaders",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -15,7 +15,8 @@
           "config": {
             "messageType": "REQUEST",
             "remove": [
-              "Content-Type"
+              "Content-Type",
+              "X-Request-ID"
             ],
             "add": {
               "Content-Type": [
@@ -87,13 +88,18 @@
         },
         {
           "comment": "Set Host header for downstream",
-          "name" : "HeaderFilter-ChangeHostToIAM",
-          "type" : "HeaderFilter",
-          "config" : {
-            "messageType" : "REQUEST",
-            "remove" : [ "host", "X-Forwarded-Host" ],
-            "add" : {
-              "X-Forwarded-Host" : [ "&{identity.platform.fqdn}" ]
+          "name": "HeaderFilter-ChangeHostToIAM",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host"
+            ],
+            "add": {
+              "X-Forwarded-Host": [
+                "&{identity.platform.fqdn}"
+              ]
             }
           }
         },
@@ -118,9 +124,23 @@
               }
             }
           }
+        },
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
+          "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext",
+          "name": "FapiTransactionIdFilter-1",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "FapiTransactionIdFilter.groovy"
+          }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "ForgeRockClientHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -9,6 +9,20 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
+          "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext",
+          "name": "FapiTransactionIdFilter-1",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "FapiTransactionIdFilter.groovy"
+          }
+        },        
+        {
           "comment": "Enforce response content type as application/json",
           "name": "HeaderFilter-AddResponseHeaders",
           "type": "HeaderFilter",
@@ -124,23 +138,9 @@
               }
             }
           }
-        },
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
-        {
-          "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext",
-          "name": "FapiTransactionIdFilter-1",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "FapiTransactionIdFilter.groovy"
-          }
         }
       ],
-      "handler": "ForgeRockClientHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -14,15 +14,6 @@
           "type": "FapiInteractionIdFilter"
         },
         {
-          "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext",
-          "name": "FapiTransactionIdFilter-1",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "FapiTransactionIdFilter.groovy"
-          }
-        },        
-        {
           "comment": "Enforce response content type as application/json",
           "name": "HeaderFilter-AddResponseHeaders",
           "type": "HeaderFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -1,13 +1,18 @@
 {
   "comment": "Open Banking Account Access Consents",
-  "name" : "10 - Open Banking Account Access Consent",
+  "name": "10 - Open Banking Account Access Consent",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "https://&{identity.platform.fqdn}",
-  "condition" : "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/aisp/account-access-consents')}",
+  "baseURI": "https://&{identity.platform.fqdn}",
+  "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/aisp/account-access-consents')}",
   "handler": {
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Check Open Banking compliant response",
           "name": "ObResponseCheck",
@@ -31,7 +36,7 @@
         },
         {
           "comment": "Make sure client certificate includes AISP role",
-          "name" : "CertificateRoleCheck",
+          "name": "CertificateRoleCheck",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
@@ -58,13 +63,15 @@
         },
         {
           "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
-          "name" : "OAuth2ResourceServerFilter-OB",
-          "type" : "OAuth2ResourceServerFilter",
-          "config" : {
-            "scopes" : [ "accounts" ],
-            "requireHttps" : false,
-            "realm" : "OpenIG",
-            "accessTokenResolver" : {
+          "name": "OAuth2ResourceServerFilter-OB",
+          "type": "OAuth2ResourceServerFilter",
+          "config": {
+            "scopes": [
+              "accounts"
+            ],
+            "requireHttps": false,
+            "realm": "OpenIG",
+            "accessTokenResolver": {
               "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
@@ -124,11 +131,13 @@
         },
         {
           "comment": "Add Host header for downstream IDM",
-          "name" : "HeaderFilter-ChangeHostToIDM",
-          "type" : "HeaderFilter",
-          "config" : {
-            "messageType" : "REQUEST",
-            "remove" : [ "host" ]
+          "name": "HeaderFilter-ChangeHostToIDM",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host"
+            ]
           }
         },
         {
@@ -146,7 +155,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -1,13 +1,21 @@
 {
-  "name" : "11 - Open Banking Account Access",
+  "name": "11 - Open Banking Account Access",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "https://&{rs.fqdn}",
-  "condition" : "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/aisp/accounts')}",
-  "capture" : [ "response", "request" ],
-  "handler" : {
-    "type" : "Chain",
-    "config" : {
-      "filters" : [
+  "baseURI": "https://&{rs.fqdn}",
+  "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/aisp/accounts')}",
+  "capture": [
+    "response",
+    "request"
+  ],
+  "handler": {
+    "type": "Chain",
+    "config": {
+      "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Ensure OB compliant response",
           "name": "ObResponseCheck",
@@ -31,7 +39,7 @@
         },
         {
           "comment": "Ensure client certificate includes AISP role",
-          "name" : "CertificateRoleCheck",
+          "name": "CertificateRoleCheck",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
@@ -79,13 +87,16 @@
         },
         {
           "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
-          "name" : "OAuth2ResourceServerFilter-OB",
-          "type" : "OAuth2ResourceServerFilter",
-          "config" : {
-            "scopes" : [ "accounts", "openid" ],
-            "requireHttps" : false,
-            "realm" : "OpenIG",
-            "accessTokenResolver" : {
+          "name": "OAuth2ResourceServerFilter-OB",
+          "type": "OAuth2ResourceServerFilter",
+          "config": {
+            "scopes": [
+              "accounts",
+              "openid"
+            ],
+            "requireHttps": false,
+            "realm": "OpenIG",
+            "accessTokenResolver": {
               "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
@@ -116,22 +127,30 @@
         },
         {
           "comment": "Check consent authorised via AM authz policy",
-          "name" : "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
-          "type" : "PolicyEnforcementFilter",
-          "config" : {
-            "pepRealm" : "/&{am.realm}",
-            "application" : "Open Banking",
-            "claimsSubject" : {
+          "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
+          "type": "PolicyEnforcementFilter",
+          "config": {
+            "pepRealm": "/&{am.realm}",
+            "application": "Open Banking",
+            "claimsSubject": {
               "sub": "${contexts.oauth2.accessToken.info.sub}",
               "intent_type": "aisp"
             },
             "environment": {
-              "sub": [ "${contexts.oauth2.accessToken.info.sub}" ],
-              "tpp_client_id" : [ "${contexts.oauth2.accessToken.info.aud}" ],
-              "tpp_cert_id" : [ "${attributes.tppId}" ],
-              "intent_id": [ "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}" ]
+              "sub": [
+                "${contexts.oauth2.accessToken.info.sub}"
+              ],
+              "tpp_client_id": [
+                "${contexts.oauth2.accessToken.info.aud}"
+              ],
+              "tpp_cert_id": [
+                "${attributes.tppId}"
+              ],
+              "intent_id": [
+                "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}"
+              ]
             },
-            "amService" : "AmService-OBIE",
+            "amService": "AmService-OBIE",
             "failureHandler": {
               "type": "ScriptableHandler",
               "config": {
@@ -172,18 +191,23 @@
         },
         {
           "comment": "Add host header for downstream resource server",
-          "name" : "HeaderFilter-ChangeHostToRS",
-          "type" : "HeaderFilter",
-          "config" : {
-            "messageType" : "REQUEST",
-            "remove" : [ "host", "X-Forwarded-Host" ],
-            "add" : {
-              "X-Forwarded-Host" : [ "rs.dev.forgerock.financial" ]
+          "name": "HeaderFilter-ChangeHostToRS",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host"
+            ],
+            "add": {
+              "X-Forwarded-Host": [
+                "rs.dev.forgerock.financial"
+              ]
             }
           }
         }
       ],
-      "handler" : "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -11,11 +11,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Ensure OB compliant response",
           "name": "ObResponseCheck",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -1,13 +1,21 @@
 {
-  "name" : "12 - Open Banking Account Access multiple routes",
+  "name": "12 - Open Banking Account Access multiple routes",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "https://&{rs.fqdn}",
-  "condition" : "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/(aisp/balances|aisp/transactions|aisp/beneficiaries|aisp/direct-debits|aisp/standing-orders|aisp/products|aisp/offers|aisp/party|aisp/scheduled-payments|aisp/statements)')}",
-  "capture" : [ "response", "request" ],
-  "handler" : {
-    "type" : "Chain",
-    "config" : {
-      "filters" : [
+  "baseURI": "https://&{rs.fqdn}",
+  "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/(aisp/balances|aisp/transactions|aisp/beneficiaries|aisp/direct-debits|aisp/standing-orders|aisp/products|aisp/offers|aisp/party|aisp/scheduled-payments|aisp/statements)')}",
+  "capture": [
+    "response",
+    "request"
+  ],
+  "handler": {
+    "type": "Chain",
+    "config": {
+      "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Ensure OB compliant response",
           "name": "ObResponseCheck",
@@ -31,7 +39,7 @@
         },
         {
           "comment": "Ensure client certificate includes AISP role",
-          "name" : "CertificateRoleCheck",
+          "name": "CertificateRoleCheck",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
@@ -79,13 +87,16 @@
         },
         {
           "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
-          "name" : "OAuth2ResourceServerFilter-OB",
-          "type" : "OAuth2ResourceServerFilter",
-          "config" : {
-            "scopes" : [ "accounts", "openid" ],
-            "requireHttps" : false,
-            "realm" : "OpenIG",
-            "accessTokenResolver" : {
+          "name": "OAuth2ResourceServerFilter-OB",
+          "type": "OAuth2ResourceServerFilter",
+          "config": {
+            "scopes": [
+              "accounts",
+              "openid"
+            ],
+            "requireHttps": false,
+            "realm": "OpenIG",
+            "accessTokenResolver": {
               "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
@@ -116,22 +127,30 @@
         },
         {
           "comment": "Check consent authorised via AM authz policy",
-          "name" : "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
-          "type" : "PolicyEnforcementFilter",
-          "config" : {
-            "pepRealm" : "/&{am.realm}",
-            "application" : "Open Banking",
-            "claimsSubject" : {
+          "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
+          "type": "PolicyEnforcementFilter",
+          "config": {
+            "pepRealm": "/&{am.realm}",
+            "application": "Open Banking",
+            "claimsSubject": {
               "sub": "${contexts.oauth2.accessToken.info.sub}",
               "intent_type": "aisp"
             },
             "environment": {
-              "sub": [ "${contexts.oauth2.accessToken.info.sub}" ],
-              "tpp_client_id" : [ "${contexts.oauth2.accessToken.info.aud}" ],
-              "tpp_cert_id" : [ "${attributes.tppId}" ],
-              "intent_id": [ "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}" ]
+              "sub": [
+                "${contexts.oauth2.accessToken.info.sub}"
+              ],
+              "tpp_client_id": [
+                "${contexts.oauth2.accessToken.info.aud}"
+              ],
+              "tpp_cert_id": [
+                "${attributes.tppId}"
+              ],
+              "intent_id": [
+                "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}"
+              ]
             },
-            "amService" : "AmService-OBIE",
+            "amService": "AmService-OBIE",
             "failureHandler": {
               "type": "ScriptableHandler",
               "config": {
@@ -172,18 +191,23 @@
         },
         {
           "comment": "Add host header for downstream resource server",
-          "name" : "HeaderFilter-ChangeHostToRS",
-          "type" : "HeaderFilter",
-          "config" : {
-            "messageType" : "REQUEST",
-            "remove" : [ "host", "X-Forwarded-Host" ],
-            "add" : {
-              "X-Forwarded-Host" : [ "rs.dev.forgerock.financial" ]
+          "name": "HeaderFilter-ChangeHostToRS",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host"
+            ],
+            "add": {
+              "X-Forwarded-Host": [
+                "rs.dev.forgerock.financial"
+              ]
             }
           }
         }
       ],
-      "handler" : "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -11,11 +11,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Ensure OB compliant response",
           "name": "ObResponseCheck",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -1,7 +1,7 @@
 {
   "name": "30 - Open Banking RS Payment Consent Funds Confirmation",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "https://&{rs.fqdn}",
+  "baseURI": "https://&{rs.fqdn}",
   "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/pisp/domestic-payment-consents/.*/funds-confirmation$')}",
   "capture": [
     "response",
@@ -11,6 +11,11 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
@@ -82,7 +87,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -232,7 +238,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -11,11 +11,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -8,6 +8,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -198,7 +203,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",
           "type": "ScriptableFilter",
@@ -96,7 +101,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -249,7 +255,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -83,7 +88,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -220,7 +226,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -8,6 +8,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -207,7 +212,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",
           "type": "ScriptableFilter",
@@ -96,7 +101,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -275,7 +281,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -83,7 +88,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -220,7 +226,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -8,6 +8,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -78,7 +83,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -207,7 +213,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",
           "type": "ScriptableFilter",
@@ -96,7 +101,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -293,7 +299,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -83,7 +88,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -220,7 +226,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -8,6 +8,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -198,7 +203,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",
           "type": "ScriptableFilter",
@@ -96,7 +101,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -284,7 +290,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -83,7 +88,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -220,7 +226,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -1,7 +1,7 @@
 {
   "name": "48 - Open Banking RS International Payment Funds Confirmation",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "https://&{rs.fqdn}",
+  "baseURI": "https://&{rs.fqdn}",
   "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/pisp/international-payment-consents/.*/funds-confirmation$')}",
   "capture": [
     "response",
@@ -11,6 +11,11 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
@@ -82,7 +87,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -232,7 +238,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -11,11 +11,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -8,6 +8,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -207,7 +212,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",
           "type": "ScriptableFilter",
@@ -96,7 +101,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -284,7 +290,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -83,7 +88,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -220,7 +226,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -1,7 +1,7 @@
 {
   "name": "53 - Open Banking RS International Scheduled Payment Funds Confirmation",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "https://&{rs.fqdn}",
+  "baseURI": "https://&{rs.fqdn}",
   "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/pisp/international-scheduled-payment-consents/.*/funds-confirmation$')}",
   "capture": [
     "response",
@@ -11,6 +11,11 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
@@ -82,7 +87,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -232,7 +238,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -11,11 +11,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
@@ -8,11 +8,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Ensure Open Banking compliant response",
           "name": "ObResponseCheck",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
@@ -1,13 +1,18 @@
 {
   "comment": "Authorise access to token endpoint",
-  "name" : "54 - Open Banking OAuth2 token endpoint",
+  "name": "54 - Open Banking OAuth2 token endpoint",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "https://&{identity.platform.fqdn}",
-  "condition" : "${matches(request.uri.path, '^/am/oauth2/realms/root/realms/&{am.realm}/access_token')}",
+  "baseURI": "https://&{identity.platform.fqdn}",
+  "condition": "${matches(request.uri.path, '^/am/oauth2/realms/root/realms/&{am.realm}/access_token')}",
   "handler": {
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Ensure Open Banking compliant response",
           "name": "ObResponseCheck",
@@ -51,7 +56,7 @@
         },
         {
           "comment": "Add the extracted cert thumbprint to the token request",
-          "name" : "AddCnf",
+          "name": "AddCnf",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
@@ -74,7 +79,7 @@
         },
         {
           "comment": "Add gateway access token to downstream request",
-          "name" : "AddGatewayAuthorization",
+          "name": "AddGatewayAuthorization",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
@@ -82,7 +87,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -8,6 +8,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -207,7 +212,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",
           "type": "ScriptableFilter",
@@ -96,7 +101,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -293,7 +299,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -83,7 +88,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -220,7 +226,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -8,6 +8,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -198,7 +203,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -6,11 +6,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -7,6 +7,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -162,7 +167,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-internal-repo.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-internal-repo.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "name": "SwitchFilter-RequestRouter",
           "type": "SwitchFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-internal-repo.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-internal-repo.json
@@ -8,6 +8,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "name": "SwitchFilter-RequestRouter",
           "type": "SwitchFilter",
           "config": {
@@ -73,4 +78,4 @@
       }
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",
           "type": "ScriptableFilter",
@@ -96,7 +101,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -284,7 +290,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Change the payment intent status to Consumed",
           "name": "ConsumeThePaymentIntent",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -13,6 +13,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -83,7 +88,8 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments", "openid"
+              "payments",
+              "openid"
             ],
             "requireHttps": false,
             "realm": "OpenIG",
@@ -220,7 +226,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -12,11 +12,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -8,6 +8,11 @@
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -184,7 +189,7 @@
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
@@ -1,8 +1,8 @@
 {
   "comment": "70 - Signing service for Remote Consent service, used to sign responses with RCS registered key",
-  "name" : "70 - OB JWKMS",
+  "name": "70 - OB JWKMS",
   "auditService": "AuditService-OB-Route",
-  "condition" : "${matches(request.uri.path, '^/jwkms/rcs/signresponse')}",
+  "condition": "${matches(request.uri.path, '^/jwkms/rcs/signresponse')}",
   "heap": [
     {
       "name": "SecretKeyPropertyFormat-RCS",
@@ -16,10 +16,12 @@
       "name": "SystemAndEnvSecretStore-RCS",
       "type": "SystemAndEnvSecretStore",
       "config": {
-        "mappings": [{
-          "secretId": "ig.rcs.secret",
-          "format": "SecretKeyPropertyFormat-RCS"
-        }]
+        "mappings": [
+          {
+            "secretId": "ig.rcs.secret",
+            "format": "SecretKeyPropertyFormat-RCS"
+          }
+        ]
       }
     }
   ],
@@ -27,6 +29,11 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Prepare JWT payload",
           "name": "JwkmsProcessRequest",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
@@ -29,11 +29,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Prepare JWT payload",
           "name": "JwkmsProcessRequest",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
@@ -29,11 +29,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Extract certificate details for organizational claims in SSA",
           "name": "ParseCertificate",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
@@ -1,8 +1,8 @@
 {
   "comment": "Create SSA for test TPP clients to use in OIDC dynamic registration",
-  "name" : "72 - API client onboarding - generate test SSA",
+  "name": "72 - API client onboarding - generate test SSA",
   "auditService": "AuditService-OB-Route",
-  "condition" : "${matches(request.uri.path, '^/jwkms/apiclient/getssa')}",
+  "condition": "${matches(request.uri.path, '^/jwkms/apiclient/getssa')}",
   "heap": [
     {
       "name": "SecretKeyPropertyFormat-SSA",
@@ -16,10 +16,12 @@
       "name": "SystemAndEnvSecretStore-SSA",
       "type": "SystemAndEnvSecretStore",
       "config": {
-        "mappings": [{
-          "secretId": "ig.ssa.secret",
-          "format": "SecretKeyPropertyFormat-SSA"
-        }]
+        "mappings": [
+          {
+            "secretId": "ig.ssa.secret",
+            "format": "SecretKeyPropertyFormat-SSA"
+          }
+        ]
       }
     }
   ],
@@ -27,6 +29,11 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "comment": "Extract certificate details for organizational claims in SSA",
           "name": "ParseCertificate",
@@ -47,8 +54,8 @@
             "type": "application/x-groovy",
             "file": "JwkmsBuildSSA.groovy",
             "args": {
-                "routeArgJwtIssuer": "test-publisher",
-                "routeArgJwtValidity": 300
+              "routeArgJwtIssuer": "test-publisher",
+              "routeArgJwtValidity": 300
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/73-ob-jwkms-apiclient-signclaims.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/73-ob-jwkms-apiclient-signclaims.json
@@ -1,14 +1,18 @@
 {
   "comment": "Signing service for TPPs with test JWK set",
-  "name" : "73 - Test TPP signing service",
+  "name": "73 - Test TPP signing service",
   "auditService": "AuditService-OB-Route",
-  "condition" : "${matches(request.uri.path, '^/jwkms/apiclient/signclaims')}",
-  "heap": [
-  ],
+  "condition": "${matches(request.uri.path, '^/jwkms/apiclient/signclaims')}",
+  "heap": [],
   "handler": {
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        }
       ],
       "handler": {
         "comment": "Sign claims using signing key from incoming JWK set",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/73-ob-jwkms-apiclient-signclaims.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/73-ob-jwkms-apiclient-signclaims.json
@@ -8,11 +8,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        }
+        "SBATFapiInteractionFilterChain"
       ],
       "handler": {
         "comment": "Sign claims using signing key from incoming JWK set",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/80-jwks-proxy.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/80-jwks-proxy.json
@@ -1,12 +1,17 @@
 {
   "comment": "JWK set proxy - provides publicly trusted route to Open Banking JWK publishing points protected with non-public SSL certs",
-  "name" : "80 - Open Banking JWKS Proxy",
+  "name": "80 - Open Banking JWKS Proxy",
   "auditService": "AuditService-OB-Route",
-  "condition" : "${matches(request.uri.path, '^/jwkms/jwksproxy')}",
+  "condition": "${matches(request.uri.path, '^/jwkms/jwksproxy')}",
   "handler": {
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
         {
           "name": "JWKSProxyProcessRequest",
           "type": "ScriptableFilter",
@@ -30,9 +35,13 @@
           "type": "HeaderFilter",
           "config": {
             "messageType": "RESPONSE",
-            "remove": [ "Content-Type" ],
+            "remove": [
+              "Content-Type"
+            ],
             "add": {
-              "Content-Type": [ "application/json" ]
+              "Content-Type": [
+                "application/json"
+              ]
             }
           }
         }
@@ -40,4 +49,4 @@
       "handler": "OBReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/80-jwks-proxy.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/80-jwks-proxy.json
@@ -7,11 +7,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "name": "JWKSProxyProcessRequest",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/99-ob-as.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/99-ob-as.json
@@ -8,11 +8,7 @@
     "type": "Chain",
     "config": {
       "filters": [
-        {
-          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-          "name": "FapiInteractionIdFilter",
-          "type": "FapiInteractionIdFilter"
-        },
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add host header to downstream request",
           "name": "HeaderFilter-ChangeHostToIAM",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/99-ob-as.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/99-ob-as.json
@@ -1,27 +1,37 @@
 {
   "comment": "Passthrough for any unprotected AM endpoints",
-  "name" : "99 - OBIE AS General",
+  "name": "99 - OBIE AS General",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "https://&{identity.platform.fqdn}",
-  "condition" : "${matches(request.uri.path, '^/am')}",
+  "baseURI": "https://&{identity.platform.fqdn}",
+  "condition": "${matches(request.uri.path, '^/am')}",
   "handler": {
     "type": "Chain",
     "config": {
       "filters": [
         {
+          "comment": "Add x-fapi-interaction-id header if one was not present in the request",
+          "name": "FapiInteractionIdFilter",
+          "type": "FapiInteractionIdFilter"
+        },
+        {
           "comment": "Add host header to downstream request",
-          "name" : "HeaderFilter-ChangeHostToIAM",
-          "type" : "HeaderFilter",
-          "config" : {
-            "messageType" : "REQUEST",
-            "remove" : [ "host", "X-Forwarded-Host" ],
-            "add" : {
-              "X-Forwarded-Host" : [ "&{ig.fqdn}" ]
+          "name": "HeaderFilter-ChangeHostToIAM",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host"
+            ],
+            "add": {
+              "X-Forwarded-Host": [
+                "&{ig.fqdn}"
+              ]
             }
           }
         }
       ],
-      "handler": "ReverseProxyHandler"
+      "handler": "SBATReverseProxyHandler"
     }
   }
-} 
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/AddCnfKey.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/AddCnfKey.groovy
@@ -1,6 +1,9 @@
 import java.util.Base64
 
-SCRIPT_NAME = "[AddCnfKey] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[AddCnfKey] (" + fapiInteractionId + ") - "
 logger.debug(SCRIPT_NAME + "Running...")
 def cnfKey = "{ \"x5t#S256\" : \"" + attributes._ig_client_certificate_thumbprint__ + "\" }"
 

--- a/config/7.1.0/securebanking/ig/scripts/groovy/AddDetachedSig.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/AddDetachedSig.groovy
@@ -16,7 +16,10 @@ import org.forgerock.http.protocol.Status
  *
  */
 
-SCRIPT_NAME = "[AddDetachedSig] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[AddDetachedSig] (" + fapiInteractionId + ") - "
+
 IAT_CRIT_CLAIM = "http://openbanking.org.uk/iat"
 ISS_CRIT_CLAIM = "http://openbanking.org.uk/iss"
 TAN_CRIT_CLAIM = "http://openbanking.org.uk/tan"

--- a/config/7.1.0/securebanking/ig/scripts/groovy/AddGatewayAuthorization.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/AddGatewayAuthorization.groovy
@@ -7,7 +7,10 @@
  *
  */
 
-SCRIPT_NAME = "[AddGatewayAuthorization] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[AddGatewayAuthorization] (" + fapiInteractionId + ") - "
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 def authHeader = request.getHeaders().getFirst("Authorization");

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ApiProtection.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ApiProtection.groovy
@@ -1,4 +1,8 @@
-SCRIPT_NAME = "[ApiProtection] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[ApiProtection] (" + fapiInteractionId + ") - "
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 next.handle(context, request)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/AuditConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/AuditConsent.groovy
@@ -1,6 +1,12 @@
 import static org.forgerock.json.resource.Requests.newCreateRequest;
 import static org.forgerock.json.resource.ResourcePath.resourcePath;
 
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[AuditConsent] (" + fapiInteractionId + ") - "
+
+logger.debug(SCRIPT_NAME + "Running...")
+
 // Helper functions
 def String transactionId() {
   return contexts.transactionId.transactionId.value;

--- a/config/7.1.0/securebanking/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
@@ -13,7 +13,11 @@ import static org.forgerock.util.promise.Promises.newResultPromise
 import java.nio.charset.Charset;
 import org.forgerock.util.encode.Base64;
 
-SCRIPT_NAME = "[BasicAuthResourceServerFilter] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[BasicAuthResourceServerFilter] (" + fapiInteractionId + ") - "
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 String authorizationHeader = request.getHeaders().getFirst("Authorization");

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CalculateResponseElementsInRS.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CalculateResponseElementsInRS.groovy
@@ -1,7 +1,10 @@
 import org.forgerock.http.protocol.*
 import org.forgerock.json.jose.*
 
-SCRIPT_NAME = "[CalculateResponseElementsInRS] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[CalculateResponseElementsInRS] (" + fapiInteractionId + ") - "
+
 logger.debug(SCRIPT_NAME + "Running...")
 def method = request.method
 

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CertificateRoleCheck.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CertificateRoleCheck.groovy
@@ -2,8 +2,10 @@ import org.forgerock.http.protocol.*
 import org.forgerock.json.jose.*
 
 // Check transport certificate for roles appropriate to request
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[CertificateRoleCheck] (" + fapiInteractionId + ") - ";
 
-SCRIPT_NAME = "[CertificateRoleCheck] - "
 logger.debug(SCRIPT_NAME + "Running...")
 
 logger.debug(SCRIPT_NAME + "Checking certificate roles for {} request",routeArgRole)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CheckFrequencyValue.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CheckFrequencyValue.groovy
@@ -2,8 +2,10 @@
  * The script validates if the current request entity contains a valid value for the Frequency field.
  * The frequency field should be found under this hierarchy in the request JSON payload: Data.Initiation.Frequency
  */
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[CheckFrequencyValue] (" + fapiInteractionId + ") - ";
 
-SCRIPT_NAME = "[CheckFrequencyValue] - "
 FREQUENCY_REGEX = "^(EvryDay)\$|^(EvryWorkgDay)\$|^(IntrvlWkDay:0[1-9]:0[1-7])\$|^(WkInMnthDay:0[1-5]:0[1-7])\$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))\$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))\$"
 logger.debug(SCRIPT_NAME + "Running...")
 

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ConsumeThePaymentIntent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ConsumeThePaymentIntent.groovy
@@ -1,6 +1,9 @@
 import groovy.json.JsonOutput
 
-SCRIPT_NAME = "[ConsumeThePaymentIntent] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ConsumeThePaymentIntent] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 /**

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -12,7 +12,9 @@ import static org.forgerock.util.promise.Promises.newResultPromise
 // TODO: handle IDM error response - pass back to caller?
 // TODO: handle AM bad response - reformat to OB
 
-SCRIPT_NAME = "[CreateApiClient] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[CreateApiClient] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def errorResponse(httpCode, message) {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/EncodeInitiation.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/EncodeInitiation.groovy
@@ -1,7 +1,9 @@
 import groovy.json.JsonOutput
 import java.util.Base64
 
-SCRIPT_NAME = "[EncodeInitiation] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[EncodeInitiation] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def initiationRequest = Base64.getEncoder().encodeToString(JsonOutput.toJson(request.entity.getJson().Data.Initiation).bytes)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
@@ -1,7 +1,7 @@
 import org.forgerock.services.context.TransactionIdContext
 import org.forgerock.services.TransactionId
 
-SCRIPT_NAME = "[TransactionIdFilter] - "
+SCRIPT_NAME = "[FapiTransactionIdFilter] - "
 logger.debug(SCRIPT_NAME + "Running...")
 
 String interactionId = request.getHeaders().getFirst("x-fapi-interaction-id");

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
@@ -1,0 +1,13 @@
+import org.forgerock.services.context.TransactionIdContext
+import org.forgerock.services.TransactionId
+
+SCRIPT_NAME = "[TransactionIdFilter] - "
+logger.debug(SCRIPT_NAME + "Running...")
+
+String interactionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if (interactionId != null) {
+    logger.debug(SCRIPT_NAME + "Found x-fapi-interaction-id: " + interactionId + " setting as TransactionId")
+    TransactionIdContext newContext = new TransactionIdContext(context, new TransactionId(interactionId));
+    return next.handle(newContext, request);
+}
+return next.handle(context, request);

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
@@ -1,7 +1,9 @@
 import org.forgerock.services.context.TransactionIdContext
 import org.forgerock.services.TransactionId
 
-SCRIPT_NAME = "[FapiTransactionIdFilter] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[FapiTransactionIdFilter] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 String interactionId = request.getHeaders().getFirst("x-fapi-interaction-id");

--- a/config/7.1.0/securebanking/ig/scripts/groovy/GetResourceOwnerIdFromConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/GetResourceOwnerIdFromConsent.groovy
@@ -1,6 +1,9 @@
 import groovy.json.JsonSlurper
 
-SCRIPT_NAME = "[GetResourceOwnerIdFromConsent] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[GetResourceOwnerIdFromConsent] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 /**
  *  definitions

--- a/config/7.1.0/securebanking/ig/scripts/groovy/GrantTypeVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/GrantTypeVerifier.groovy
@@ -1,6 +1,8 @@
 import org.forgerock.http.protocol.*
 
-SCRIPT_NAME = "[GrantTypeVerifier] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[GrantTypeVerifier] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def tokenGrantType = contexts.oauth2.accessToken.info.grant_type

--- a/config/7.1.0/securebanking/ig/scripts/groovy/JWKSProxyProcessRequest.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/JWKSProxyProcessRequest.groovy
@@ -3,7 +3,10 @@
 
 import groovy.json.JsonSlurper;
 
-SCRIPT_NAME = "[JWKSProxyProcessRequest] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[JWKSProxyProcessRequest] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 def errorResponse(httpCode, message) {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsBuildSSA.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsBuildSSA.groovy
@@ -3,7 +3,10 @@ import org.forgerock.json.jose.*
 import org.forgerock.json.jose.jwk.store.JwksStore.*
 import org.forgerock.json.JsonValueFunctions.*
 
-SCRIPT_NAME = "[JwkmsBuildSSA] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[JwkmsBuildSSA] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 logger.debug(SCRIPT_NAME + "Creating SSA")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsGetTlsCert.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsGetTlsCert.groovy
@@ -5,7 +5,9 @@ import java.security.*;
 import java.security.cert.X509Certificate
 import java.io.StringWriter;
 
-SCRIPT_NAME = "[JwkmsGetTlsCert] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[JwkmsGetTlsCert] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def getTlsKey(jwks) {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsIssueCert.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsIssueCert.groovy
@@ -45,7 +45,11 @@ QC_STATEMENTS_QWAC  = "MIHLMAgGBgQAjkYBATATBgYEAI5GAQYwCQYHBACORgEGAzAJBgcEAIvsS
 QC_STATEMENTS_QSEAL = "MIHLMAgGBgQAjkYBATATBgYEAI5GAQYwCQYHBACORgEGAjAJBgcEAIvsSQECMIGeBgYEAIGYJwIwgZMwajApBgcEAIGYJwEEDB5DYXJkIEJhc2VkIFBheW1lbnQgSW5zdHJ1bWVudHMwHgYHBACBmCcBAwwTQWNjb3VudCBJbmZvcm1hdGlvbjAdBgcEAIGYJwECDBJQYXltZW50IEluaXRpYXRpb24MHUZvcmdlUm9jayBGaW5hbmNpYWwgQXV0aG9yaXR5DAZHQi1GRkE="
 BC_PROVIDER = "BC";
 KEY_ALGORITHM = "RSA";
-SCRIPT_NAME = "[JwkmsIssueCert] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[JwkmsIssueCert] (" + fapiInteractionId + ") - ";
+
 enum EidasCertType{
     SEAL, WAC
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsProcessRCSClaims.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsProcessRCSClaims.groovy
@@ -3,7 +3,11 @@ import org.forgerock.json.jose.*
 import org.forgerock.json.jose.jwk.store.JwksStore.*
 import org.forgerock.json.JsonValueFunctions.*
 
-SCRIPT_NAME = "[JwkmsProcessRCSClaims] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[JwkmsProcessRCSClaims] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 logger.debug(SCRIPT_NAME + "Signing claims as RCS")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsSignClientClaims.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsSignClientClaims.groovy
@@ -20,7 +20,10 @@ import com.nimbusds.jose.jwk.JWKSet
 
 import groovy.json.JsonOutput
 
-SCRIPT_NAME = "[JwkmsSignClientClaims] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[JwkmsSignClientClaims] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 logger.debug(SCRIPT_NAME + "Signing claims as ApiClient")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ObResponseCheck.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ObResponseCheck.groovy
@@ -16,7 +16,9 @@ import groovy.json.JsonSlurper
  * If HTTP error response with no OB error in shared state, set response body to generic OB error
  */
 
-SCRIPT_NAME = "[ObResponseCheck] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ObResponseCheck] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 String HEADER_INTERACTION_ID = "x-fapi-interaction-id"

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
@@ -22,7 +22,10 @@ import java.security.interfaces.RSAPublicKey;
  * Utility funcs for parsing certificate contents
  */
 
-SCRIPT_NAME = "[ParseCertificate] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ParseCertificate] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 class CertificateParserHelper {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/PatchFileConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/PatchFileConsent.groovy
@@ -3,8 +3,9 @@ import org.forgerock.json.jose.*
 import groovy.json.JsonOutput
 
 // Start script processing area
-
-SCRIPT_NAME = "[PatchFileConsent] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[PatchFileConsent] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def splitUri = request.uri.path.split("/")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessAccountConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessAccountConsent.groovy
@@ -8,7 +8,9 @@ import java.util.UUID
  * Output: IDM create object
  */
 
-SCRIPT_NAME = "[ProcessAccountConsent] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ProcessAccountConsent] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def oauth2ClientId = contexts.oauth2.accessToken.info.client_id

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessDetachedSig.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessDetachedSig.groovy
@@ -29,7 +29,9 @@ JWS spec: https://www.rfc-editor.org/rfc/rfc7515#page-7
  and any TPPs using these ASPSPs must do the same.
  */
 
-SCRIPT_NAME = "[ProcessDetachedSig] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ProcessDetachedSig] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def method = request.method

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessPaymentConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessPaymentConsent.groovy
@@ -6,7 +6,10 @@ import java.text.SimpleDateFormat
  * Output: IDM create object
  */
 
-SCRIPT_NAME = "[ProcessPaymentConsent] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ProcessPaymentConsent] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 def apiClientId = contexts.oauth2.accessToken.info.client_id

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -17,7 +17,9 @@ import static org.forgerock.util.promise.Promises.newResultPromise
  * Output: Verified OIDC registration JSON
  */
 
-SCRIPT_NAME = "[ProcessRegistration] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[ProcessRegistration] (" + fapiInteractionId + ") - "
 logger.debug(SCRIPT_NAME + "Running...")
 
 def errorResponse(httpCode, message) {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRs.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRs.groovy
@@ -1,6 +1,9 @@
 import org.forgerock.http.protocol.*
 
-SCRIPT_NAME = "[ProcessRs] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ProcessRs] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 next.handle(context, request).thenOnResult(response -> {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/RepoApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RepoApiClient.groovy
@@ -1,6 +1,8 @@
 import groovy.json.JsonOutput
 
-SCRIPT_NAME = "[RepoApiClient] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[RepoApiClient] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 // Fetch the API Client from IDM

--- a/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
@@ -1,7 +1,9 @@
 import groovy.json.JsonOutput
 import java.text.SimpleDateFormat
 
-SCRIPT_NAME = "[RepoConsent] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[RepoConsent] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def buildPatchRequest(incomingRequest, intentType) {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/RepoUser.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RepoUser.groovy
@@ -1,6 +1,9 @@
 import groovy.json.JsonOutput
 
-SCRIPT_NAME = "[RepoUser] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[RepoUser] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 // Fetch the API Client from IDM

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ReturnInvalidCnfKeyError.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ReturnInvalidCnfKeyError.groovy
@@ -1,4 +1,7 @@
-SCRIPT_NAME = "[ReturnInvalidCnfKey] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ReturnInvalidCnfKeyError] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def response = new Response(Status.UNAUTHORIZED);

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ReturnPolicyValidationError.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ReturnPolicyValidationError.groovy
@@ -1,4 +1,7 @@
-SCRIPT_NAME = "[ReturnPolicyValidationError] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ReturnPolicyValidationError] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def response = new Response(Status.UNAUTHORIZED);

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -4,7 +4,10 @@ import java.net.URI;
 import java.security.SignatureException
 import static org.forgerock.util.promise.Promises.newResultPromise
 
-SCRIPT_NAME = "[SSAVerifier] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[SSAVerifier] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SaveIntentIdOnAttributesContext.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SaveIntentIdOnAttributesContext.groovy
@@ -4,7 +4,10 @@
 import org.forgerock.http.protocol.*
 import org.forgerock.http.util.Json
 
-SCRIPT_NAME = "[SaveIntentIdOnAttributesContext] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[SaveIntentIdOnAttributesContext] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 def intentId = JsonValue.json(Json.readJson(contexts.oauth2.accessToken.info.claims)).get("id_token").get("openbanking_intent_id").get("value").asString()

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ScheduledPaymentExecutionTimeVerification.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ScheduledPaymentExecutionTimeVerification.groovy
@@ -1,7 +1,8 @@
 import org.joda.time.DateTime;
 
-
-SCRIPT_NAME = "[ScheduledPaymentExecutionTimeVerification] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ScheduledPaymentExecutionTimeVerification] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def method = request.method

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SetContentTypeToPlainText.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SetContentTypeToPlainText.groovy
@@ -1,4 +1,8 @@
-SCRIPT_NAME = "[SetContentTypeToPlainText] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[SetContentTypeToPlainText] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 def response = new Response(Status.OK);

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SettingNewEntity.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SettingNewEntity.groovy
@@ -1,4 +1,7 @@
-SCRIPT_NAME = "[SettingNewEntity] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[SettingNewEntity] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def newEntity = request.getEntity().getString().replace('grant_type=client_credentials','grant_type=password&username=' + userId + '&password=' + java.net.URLEncoder.encode(password, 'UTF-8'))

--- a/config/7.1.0/securebanking/ig/scripts/groovy/TranslateAccountsResource.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/TranslateAccountsResource.groovy
@@ -1,4 +1,7 @@
-SCRIPT_NAME = "[TranslateAccountsResource] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[TranslateAccountsResource] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 String[] grantedAccounts = contexts.policyDecision.attributes.grantedAccounts

--- a/config/7.1.0/securebanking/ig/scripts/groovy/TranslatePaymentFundsConfirmationResource.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/TranslatePaymentFundsConfirmationResource.groovy
@@ -1,4 +1,7 @@
-SCRIPT_NAME = "[TranslatePaymentFundsConfirmationResource] - "
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[TranslatePaymentFundsConfirmationResource] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 request.uri.path = request.uri.path.replaceFirst("/open-banking/.*","/backoffice/payment-funds-confirmation")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/TranslatePaymentResource.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/TranslatePaymentResource.groovy
@@ -1,4 +1,6 @@
-SCRIPT_NAME = "[TranslatePaymentResource] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[TranslatePaymentResource] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 request.headers.add(routeArgAccountIdHeader, attributes.get("accountId"))

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ValidateFileConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ValidateFileConsent.groovy
@@ -2,8 +2,10 @@ import org.forgerock.http.protocol.*
 import org.forgerock.json.jose.*
 
 // Start script processing area
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ValidateFileConsent] (" + fapiInteractionId + ") - ";
 
-SCRIPT_NAME = "[ValidateFileConsent] - "
 logger.debug(SCRIPT_NAME + "Running...")
 
 def splitUri = request.uri.path.split("/")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/WellKnownFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/WellKnownFilter.groovy
@@ -1,4 +1,7 @@
-SCRIPT_NAME = "[WellKnownFilter] - "
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[WellKnownFilter] (" + fapiInteractionId + ") - ";
+
 logger.debug(SCRIPT_NAME + "Running...")
 
 next.handle(context, request).thenOnResult(response -> {

--- a/docker/7.1.0/ig/Dockerfile
+++ b/docker/7.1.0/ig/Dockerfile
@@ -3,9 +3,6 @@ FROM gcr.io/forgerock-io/ig:7.1.0
 # Copy all config files into the docker image.
 # The default ig directory is /var/ig, and it expects subfolders config/ and scripts/ (if required)
 
-ENV JAVA_OPTS="-Dorg.forgerock.http.TrustTransactionHeader=true"
-RUN echo "JAVA_OPTS set to ${JAVA_OPTS}"
-
 COPY --chown=forgerock:root . /var/ig
 COPY --chown=forgerock:root lib /opt/ig/lib
 

--- a/docker/7.1.0/ig/Dockerfile
+++ b/docker/7.1.0/ig/Dockerfile
@@ -3,6 +3,9 @@ FROM gcr.io/forgerock-io/ig:7.1.0
 # Copy all config files into the docker image.
 # The default ig directory is /var/ig, and it expects subfolders config/ and scripts/ (if required)
 
+ENV JAVA_OPTS="-Dorg.forgerock.http.TrustTransactionHeader=true"
+RUN echo "JAVA_OPTS set to ${JAVA_OPTS}"
+
 COPY --chown=forgerock:root . /var/ig
 COPY --chown=forgerock:root lib /opt/ig/lib
 


### PR DESCRIPTION
Create a filter as suggested by Guillaume Sauthier in the following issue: https://bugster.forgerock.org/jira/browse/OPENIG-6538

The aim is to set the transactionIdContext to be the value of the x-fapi-interaction-id. This _should_ ensure that the value of the x-fapi-interaction-id assigned by IG is passed to AM & IDM as the x-forgerock-transactionid header and will make logs traceable across the system.

Also in this PR:
1. Modify routes to set the x-fapi-interaction-id if it is not set
2. Set the transaction context to the value of the x-fapi-interaction-id. This results in the x-forgerock-transactionid passed to requests to the FR Platform to have the same value as the x-fapi-interaction-id
3. Modify the IG scripts to include the x-fapi-interaction-id in their log messages

The route all now have the "SBATFapiInteractionFilterChain" defined at the start of the filter chain. This is a ChainOfFilters that performs actions 1 & 2 above. 

Observations: IDM is not using the x-forgerock-transactionid for it's logging. Further work will be needed to make this happen.

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/257