### PR TITLE
624: Validating the DCR JWT signature

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -307,6 +307,10 @@
         "maxCacheEntries": 500,
         "expireAfterWriteDuration": "24 hours"
       }
+    },
+    {
+      "name": "RsaJwtSignatureValidator",
+      "type": "com.forgerock.securebanking.uk.gateway.jws.RsaJwtSignatureValidator"
     }
   ],
   "monitor": true

--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -202,6 +202,10 @@
         "maxCacheEntries": 500,
         "expireAfterWriteDuration": "1 hour"
       }
+    },
+    {
+      "name": "RsaJwtSignatureValidator",
+      "type": "com.forgerock.securebanking.uk.gateway.jws.RsaJwtSignatureValidator"
     }
   ],
   "monitor": true

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -49,7 +49,7 @@
               "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy",
               "jwkSetService": "${heap['OBJwkSetService']}",
               "allowIgIssuedTestCerts": "${security.allowIgIssuedTestCerts}",
-              "jwtSignatureValidator": "RsaJwtSignatureValidator"
+              "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}"
             }
           }
         },
@@ -66,7 +66,7 @@
                 "OpenBanking Ltd": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
                 "test-publisher": "https://&{ig.fqdn}/jwkms/apiclient/jwks"
               },
-              "jwtSignatureValidator": "RsaJwtSignatureValidator"
+              "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -48,7 +48,8 @@
               "routeArgObJwksHosts": "[\"keystore.openbankingtest.org.uk\"]",
               "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy",
               "jwkSetService": "${heap['OBJwkSetService']}",
-              "allowIgIssuedTestCerts": "${security.allowIgIssuedTestCerts}"
+              "allowIgIssuedTestCerts": "${security.allowIgIssuedTestCerts}",
+              "jwtSignatureValidator": "RsaJwtSignatureValidator"
             }
           }
         },
@@ -64,7 +65,8 @@
               "routeArgSSAIssuerJwksUrls": {
                 "OpenBanking Ltd": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
                 "test-publisher": "https://&{ig.fqdn}/jwkms/apiclient/jwks"
-              }
+              },
+              "jwtSignatureValidator": "RsaJwtSignatureValidator"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -2,7 +2,6 @@ import org.forgerock.util.promise.*
 import org.forgerock.http.protocol.*
 import org.forgerock.json.jose.*
 import org.forgerock.json.jose.jwk.*
-import org.forgerock.json.jose.jws.handlerss.*
 import org.forgerock.json.jose.common.JwtReconstruction
 import org.forgerock.json.jose.jws.SignedJwt
 import java.net.URI

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -8,7 +8,6 @@ import java.net.URI
 import groovy.json.JsonSlurper
 import com.forgerock.securebanking.uk.gateway.jwks.*
 import java.security.SignatureException
-import com.forgerock.securebanking.uk.gateway.jws.RsaJwtSignatureValidator
 import com.nimbusds.jose.jwk.RSAKey;
 import static org.forgerock.util.promise.Promises.newResultPromise
 
@@ -314,7 +313,7 @@ private boolean tlsClientCertExistsInJwkSet(jwkSet) {
 
 private boolean validateRegistrationJwtSignature(jwt, jwkSet) {
     try {
-        new RsaJwtSignatureValidator().validateSignature(jwt, jwkSet)
+        jwtSignatureValidator.validateSignature(jwt, jwkSet)
         return true
     } catch (SignatureException se) {
         logger.error("jwt signature validation failed", se)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -2,7 +2,6 @@ import org.forgerock.json.jose.jwk.JWKSet;
 import org.forgerock.http.protocol.Status;
 import java.net.URI;
 import java.security.SignatureException
-import com.forgerock.securebanking.uk.gateway.jws.RsaJwtSignatureValidator
 import static org.forgerock.util.promise.Promises.newResultPromise
 
 SCRIPT_NAME = "[SSAVerifier] - "
@@ -12,7 +11,7 @@ logger.debug(SCRIPT_NAME + "Running...")
 def verifySignature(signedJwt, jwksJson) {
     def jwks = JWKSet.parse(jwksJson);
     try {
-        new RsaJwtSignatureValidator().validateSignature(signedJwt, jwks)
+        jwtSignatureValidator.validateSignature(signedJwt, jwks)
         return true
     } catch (SignatureException se) {
         logger.error("jwt signature validation failed", se)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -1,53 +1,22 @@
+import java.security.SignatureException
 import org.forgerock.json.jose.jws.SigningManager;
 import org.forgerock.json.jose.jwk.JWKSet;
 import org.forgerock.http.protocol.Status;
+import com.forgerock.securebanking.uk.gateway.jws.RsaJwtSignatureValidator
 import java.net.URI;
-import static org.forgerock.util.promise.Promises.newResultPromise
 
 SCRIPT_NAME = "[SSAVerifier] - "
 logger.debug(SCRIPT_NAME + "Running...")
 
 def verifySignature(signedJwt,jwksJson) {
-
-    if (!signedJwt) {
-        logger.error(SCRIPT_NAME + "Failed to reconstruct JWT")
-        return false;
-    }
-
-    def kid = signedJwt.getHeader().getKeyId();
-
-    if (!kid) {
-        logger.error(SCRIPT_NAME + "Couldn't find kid in jwt header")
-        return false;
-    }
-
     def jwks = JWKSet.parse(jwksJson);
-
-    if (!jwks) {
-        logger.error(SCRIPT_NAME + "Failed to parse JWKS")
-        return false;
+    try {
+        new RsaJwtSignatureValidator().validateSignature(signedJwt, jwks)
+        return true
+    } catch (SignatureException se) {
+        logger.error("jwt signature validation failed", se)
+        return false
     }
-
-    def jwk = jwks.findJwk(kid);
-
-    if (!jwk) {
-        logger.error(SCRIPT_NAME + "Could jwk with kid {} in JWKS",kid)
-        return false;
-    }
-
-    def publicKey = jwk.toRSAPublicKey();
-
-    if (!publicKey) {
-        logger.error(SCRIPT_NAME + "Couldn't get RSA public key from JWKS entry for kid {}",kid);
-        return false;
-    }
-
-    def verificationHandler = new SigningManager().newRsaSigningHandler(publicKey);
-    def signatureVerified = signedJwt.verify(verificationHandler);
-
-    logger.debug(SCRIPT_NAME + "Signature verified: {}",signatureVerified);
-
-    return signatureVerified;
 }
 
 def errorResponse(httpCode, message) {
@@ -63,77 +32,89 @@ def method = request.method
 switch(method.toUpperCase()) {
 
     case "POST":
-    case "PUT":
 
-    if (!attributes.registrationJWTs) {
-        return(errorResponse(Status.UNAUTHORIZED,"No registration JWT"));
-    }
+        if (!attributes.registrationJWTs) {
+            return(errorResponse(Status.UNAUTHORIZED,"No registration JWT"));
+        }
 
-    def ssaJwt = attributes.registrationJWTs.ssaJwt;
+        def ssaJwt = attributes.registrationJWTs.ssaJwt;
 
-    if (!ssaJwt) {
-        return(errorResponse(Status.UNAUTHORIZED,"No SSA JWT"));
-    }
+        if (!ssaJwt) {
+            return(errorResponse(Status.UNAUTHORIZED,"No SSA JWT"));
+        }
 
-    if (!routeArgSSAIssuerJwksUrls) {
-        return(errorResponse(Status.INTERNAL_SERVER_ERROR,"No configured JWKS URIs"));
-    }
+        if (!routeArgSSAIssuerJwksUrls) {
+            return(errorResponse(Status.INTERNAL_SERVER_ERROR,"No configured JWKS URIs"));
+        }
 
-    def ssaClaims = ssaJwt.getClaimsSet();
+        def ssaClaims = ssaJwt.getClaimsSet();
 
-    def ssaIssuer = ssaClaims.getIssuer();
+        def ssaIssuer = ssaClaims.getIssuer();
 
-    if (!ssaIssuer) {
-        return(errorResponse(Status.UNAUTHORIZED,"SSA has no issuer"));
-    }
+        if (!ssaIssuer) {
+            return(errorResponse(Status.UNAUTHORIZED,"SSA has no issuer"));
+        }
 
-    def ssaJwksUrl = routeArgSSAIssuerJwksUrls[ssaIssuer];
+        def ssaJwksUrl = routeArgSSAIssuerJwksUrls[ssaIssuer];
 
-    if (!ssaJwksUrl) {
-        return(errorResponse(Status.UNAUTHORIZED,"Unknown SSA issuer: " + ssaIssuer));
-    }
+        if (!ssaJwksUrl) {
+            return(errorResponse(Status.UNAUTHORIZED,"Unknown SSA issuer: " + ssaIssuer));
+        }
 
-    def ssaJwksUri = null;
+        def ssaJwksUri = null;
 
-    try {
-        ssaJwksUri = new URI(ssaJwksUrl);
-    }
-    catch (e) {
-        return(errorResponse(Status.INTERNAL_SERVER_ERROR,"Error parsing JWKS URL " + ssaJwksUrl + "(" + e + ")"));
-    }
+        try {
+            ssaJwksUri = new URI(ssaJwksUrl);
+        }
+        catch (e) {
+            return(errorResponse(Status.INTERNAL_SERVER_ERROR,"Error parsing JWKS URL " + ssaJwksUrl + "(" + e + ")"));
+        }
 
-    logger.debug(SCRIPT_NAME + "Validating SSA JWT - Issuer {}, JWKS URI {}",ssaIssuer,ssaJwksUrl);
+        logger.debug(SCRIPT_NAME + "Validating SSA JWT - Issuer {}, JWKS URI {}",ssaIssuer,ssaJwksUrl);
 
-    Request jwksRequest = new Request();
-
-
-    jwksRequest.setMethod('GET');
-    jwksRequest.setUri(ssaJwksUrl);
-    // jwksRequest.getHeaders().add("Host",ssaJwksUri.getHost());
+        Request jwksRequest = new Request();
 
 
-    return http.send(jwksRequest).thenAsync(jwksResponse -> {
-      jwksRequest.close();
-      logger.debug(SCRIPT_NAME + "Back from JWKS URI");
-      def jwksResponseContent = jwksResponse.getEntity().getString();
-      def jwksResponseStatus = jwksResponse.getStatus();
+        jwksRequest.setMethod('GET');
+        jwksRequest.setUri(ssaJwksUrl);
+        // jwksRequest.getHeaders().add("Host",ssaJwksUri.getHost());
 
-      logger.debug(SCRIPT_NAME + "status " + jwksResponseStatus);
-      logger.debug(SCRIPT_NAME + "entity " + jwksResponseContent);
 
-      if (jwksResponseStatus != Status.OK) {
-          return newResultPromise(errorResponse(Status.UNAUTHORIZED,"Bad response from JWKS URI " + jwksResponseStatus))
-      }
-      else if (!verifySignature(ssaJwt,jwksResponseContent)) {
-          return newResultPromise(errorResponse(Status.UNAUTHORIZED,"Signature not verified"))
-      }
-      return next.handle(context, request)
-    })
+        http.send(jwksRequest).then(jwksResponse -> {
+
+            jwksRequest.close();
+            logger.debug(SCRIPT_NAME + "Back from JWKS URI");
+            def jwksResponseContent = jwksResponse.getEntity().getString();
+            def jwksResponseStatus = jwksResponse.getStatus();
+
+            logger.debug(SCRIPT_NAME + "status " + jwksResponseStatus);
+            logger.debug(SCRIPT_NAME + "entity " + jwksResponseContent);
+
+            if (jwksResponseStatus != Status.OK) {
+                return(errorResponse(Status.UNAUTHORIZED,"Bad response from JWKS URI " + jwksResponseStatus));
+            }
+            else if (!verifySignature(ssaJwt,jwksResponseContent)) {
+                return(errorResponse(Status.UNAUTHORIZED,"Signature not verified"));
+            }
+
+            return null;
+        }).thenAsync (error -> {
+            if (error) {
+                // TODO: This doesn't work - get cast error from Response to Promise
+                logger.error(SCRIPT_NAME + "Sending back error response");
+                return error;
+            }
+            next.handle(context, request);
+        });
+        break
 
     case "DELETE":
-    case "GET":
-        return next.handle(context, request)
+        break
     default:
         logger.debug(SCRIPT_NAME + "Method not supported")
-        return errorResponse(Status.METHOD_NOT_ALLOWED,"Method Not Allowed")
+
 }
+
+
+next.handle(context, request)
+

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -1,6 +1,7 @@
 import org.forgerock.json.jose.jwk.JWKSet;
 import org.forgerock.http.protocol.Status;
 import java.net.URI;
+import java.security.SignatureException
 import com.forgerock.securebanking.uk.gateway.jws.RsaJwtSignatureValidator
 import static org.forgerock.util.promise.Promises.newResultPromise
 

--- a/securebanking-openbanking-uk-gateway-jwks/pom.xml
+++ b/securebanking-openbanking-uk-gateway-jwks/pom.xml
@@ -77,6 +77,13 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>9.25.6</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/securebanking-openbanking-uk-gateway-jwks/src/main/java/com/forgerock/securebanking/uk/gateway/jws/JwtSignatureValidator.java
+++ b/securebanking-openbanking-uk-gateway-jwks/src/main/java/com/forgerock/securebanking/uk/gateway/jws/JwtSignatureValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.uk.gateway.jws;
+
+import java.security.SignatureException;
+
+import org.forgerock.json.jose.jwk.JWKSet;
+import org.forgerock.json.jose.jws.SignedJwt;
+
+/**
+ * Validator which validates the signature of a JWT by using a JWK in the supplied JWKSet
+ */
+public interface JwtSignatureValidator {
+
+    /**
+     * Validates the signature of the jwt, the method will return without throwing an exception if successful
+     *
+     * @param jwt    SignedJwt to validate the signature of
+     * @param jwkSet JWKSet containing a JWK to use for the validation (typically the JWK to use will be determined by the kid JWT header)
+     * @throws SignatureException if validation is unsuccessful, this may be due to the signature not matching the expected
+     *                            signature, or some other issue with the supplied jwt or jwkSet
+     */
+    void validateSignature(SignedJwt jwt, JWKSet jwkSet) throws SignatureException;
+
+}

--- a/securebanking-openbanking-uk-gateway-jwks/src/main/java/com/forgerock/securebanking/uk/gateway/jws/RsaJwtSignatureValidator.java
+++ b/securebanking-openbanking-uk-gateway-jwks/src/main/java/com/forgerock/securebanking/uk/gateway/jws/RsaJwtSignatureValidator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.uk.gateway.jws;
+
+import java.security.SignatureException;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Set;
+
+import org.forgerock.json.jose.jwk.JWK;
+import org.forgerock.json.jose.jwk.JWKSet;
+import org.forgerock.json.jose.jwk.RsaJWK;
+import org.forgerock.json.jose.jws.JwsAlgorithm;
+import org.forgerock.json.jose.jws.SignedJwt;
+import org.forgerock.json.jose.jws.SigningManager;
+import org.forgerock.json.jose.jws.handlers.SigningHandler;
+import org.forgerock.json.jose.jwt.Algorithm;
+import org.forgerock.secrets.SecretBuilder;
+import org.forgerock.secrets.SecretsProvider;
+import org.forgerock.secrets.keys.VerificationKey;
+import org.forgerock.util.Reject;
+
+/**
+ * Validator that validates a JWT using an RSA Public Key.
+ *
+ * The RSA Public Key to use is determined by looking for a JWK within the supplied JWKSet which has a kid matching the kid
+ * supplied in the JWT header. Validation will be failed if no JWK can be found to carry out the signature verification.
+ */
+public class RsaJwtSignatureValidator implements JwtSignatureValidator {
+
+    public static final String USE_SIGNING_KEY = "sig";
+
+    private final SigningManager signingManager = new SigningManager(new SecretsProvider(Clock.systemUTC()));
+
+    private final Set<Algorithm> supportedAlgorithms = Set.of(JwsAlgorithm.PS256, JwsAlgorithm.PS384, JwsAlgorithm.PS512);
+
+    @Override
+    public void validateSignature(SignedJwt jwt, JWKSet jwkSet) throws SignatureException {
+        try {
+            Reject.ifNull(jwt, "jwt must be supplied");
+            Reject.ifNull(jwkSet, "jwkSet must be supplied");
+
+            String kid = jwt.getHeader().getKeyId();
+            if (kid == null) {
+                throw new IllegalStateException("kid must be present in the JWT header");
+            }
+            final JwsAlgorithm jwsAlgorithm = jwt.getHeader().getAlgorithm();
+            if (!supportedAlgorithms.contains(jwsAlgorithm)) {
+                throw new IllegalStateException("jwt signed using unsupported algorithm: " + jwsAlgorithm);
+            }
+            JWK jwk = jwkSet.findJwk(kid);
+            if (jwk == null) {
+                throw new IllegalStateException("jwk not found in supplied jwkSet for kid: " + kid);
+            }
+            if (!(jwk instanceof RsaJWK)) {
+                throw new IllegalStateException("jwk for kid: " + kid + " must be of type RsaJwk");
+            }
+            if (!USE_SIGNING_KEY.equals(jwk.getUse())) {
+                throw new IllegalStateException("jwk for kid: " + kid + " must be signing key, instead found: " + jwk.getUse());
+            }
+            RSAPublicKey publicKey = ((RsaJWK) jwk).toRSAPublicKey();
+            final SecretBuilder secretBuilder = new SecretBuilder().publicKey(publicKey)
+                                                                   .expiresAt(Instant.MAX)
+                                                                   .stableId(kid);
+            final VerificationKey verificationKey = new VerificationKey(secretBuilder);
+            SigningHandler verificationHandler = signingManager.newRsaVerificationHandler(verificationKey);
+            if (!jwt.verify(verificationHandler)) {
+                throw new SignatureException("jwt signature verification failed");
+            }
+        } catch (SignatureException se) {
+            throw se;
+        }
+        catch (Throwable t) {
+            throw new SignatureException(t);
+        }
+    }
+}

--- a/securebanking-openbanking-uk-gateway-jwks/src/main/java/com/forgerock/securebanking/uk/gateway/jws/RsaJwtSignatureValidator.java
+++ b/securebanking-openbanking-uk-gateway-jwks/src/main/java/com/forgerock/securebanking/uk/gateway/jws/RsaJwtSignatureValidator.java
@@ -29,6 +29,8 @@ import org.forgerock.json.jose.jws.SignedJwt;
 import org.forgerock.json.jose.jws.SigningManager;
 import org.forgerock.json.jose.jws.handlers.SigningHandler;
 import org.forgerock.json.jose.jwt.Algorithm;
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
 import org.forgerock.secrets.SecretBuilder;
 import org.forgerock.secrets.SecretsProvider;
 import org.forgerock.secrets.keys.VerificationKey;
@@ -86,6 +88,16 @@ public class RsaJwtSignatureValidator implements JwtSignatureValidator {
         }
         catch (Throwable t) {
             throw new SignatureException(t);
+        }
+    }
+
+    /**
+     * Basic heaplet to allow RsaJwtSignatureValidator to be created via IG config
+     */
+    public static class Heaplet extends GenericHeaplet {
+        @Override
+        public Object create() throws HeapException {
+            return new RsaJwtSignatureValidator();
         }
     }
 }

--- a/securebanking-openbanking-uk-gateway-jwks/src/test/java/com/forgerock/securebanking/uk/gateway/jws/RsaJwtSignatureValidatorTest.java
+++ b/securebanking-openbanking-uk-gateway-jwks/src/test/java/com/forgerock/securebanking/uk/gateway/jws/RsaJwtSignatureValidatorTest.java
@@ -75,16 +75,16 @@ class RsaJwtSignatureValidatorTest {
                 .build();
     }
 
-    private SignedJwt generateSignedJwt(RSAKey key, JWTClaimsSet claimsSet) {
-        return generateSignedJwt(key, claimsSet, defaultHeaderBuilder(key));
-    }
-
     private static Builder defaultHeaderBuilder(RSAKey key) {
         return new Builder(JWSAlgorithm.PS256).keyID(key.getKeyID());
     }
 
     private static Builder headerBuilderUsingCustomKeyId(String keyId) {
         return new Builder(JWSAlgorithm.PS256).keyID(keyId);
+    }
+
+    private SignedJwt generateSignedJwt(RSAKey key, JWTClaimsSet claimsSet) {
+        return generateSignedJwt(key, claimsSet, defaultHeaderBuilder(key));
     }
 
     private SignedJwt generateSignedJwt(RSAKey key, JWTClaimsSet claimsSet, JWSHeader.Builder jwsHeaderBuilder) {

--- a/securebanking-openbanking-uk-gateway-jwks/src/test/java/com/forgerock/securebanking/uk/gateway/jws/RsaJwtSignatureValidatorTest.java
+++ b/securebanking-openbanking-uk-gateway-jwks/src/test/java/com/forgerock/securebanking/uk/gateway/jws/RsaJwtSignatureValidatorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.uk.gateway.jws;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.security.SignatureException;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.forgerock.json.jose.common.JwtReconstruction;
+import org.forgerock.json.jose.jwk.JWKSet;
+import org.forgerock.json.jose.jws.SignedJwt;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSHeader.Builder;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+class RsaJwtSignatureValidatorTest {
+
+    private static JWTClaimsSet EXAMPLE_CLAIMS_SET;
+    private static RSAKey SIGNING_KEY;
+    private static RSAKey TRANSPORT_KEY;
+    private static JWKSet JWK_SET;
+
+    private final RsaJwtSignatureValidator signatureValidator = new RsaJwtSignatureValidator();
+
+    @BeforeAll
+    public static void beforeAll() throws JOSEException {
+        SIGNING_KEY = new RSAKeyGenerator(2048)
+                .keyUse(KeyUse.SIGNATURE)
+                .keyID(UUID.randomUUID().toString())
+                .generate();
+
+        TRANSPORT_KEY = new RSAKeyGenerator(2048)
+                .keyUse(KeyUse.ENCRYPTION)
+                .keyID(UUID.randomUUID().toString())
+                .generate();
+
+        final com.nimbusds.jose.jwk.JWKSet nimbusJwkSet = new com.nimbusds.jose.jwk.JWKSet(List.of(SIGNING_KEY, TRANSPORT_KEY));
+        JWK_SET = JWKSet.parse(nimbusJwkSet.toString(true));
+
+        EXAMPLE_CLAIMS_SET = new JWTClaimsSet.Builder().issuer("test-issuer")
+                .audience("https://example.com")
+                .subject("test-tpp")
+                .claim("blah", "blah")
+                .expirationTime(new Date(System.currentTimeMillis() + TimeUnit.MILLISECONDS.toMillis(5)))
+                .build();
+    }
+
+    private SignedJwt generateSignedJwt(RSAKey key, JWTClaimsSet claimsSet) {
+        return generateSignedJwt(key, claimsSet, defaultHeaderBuilder(key));
+    }
+
+    private static Builder defaultHeaderBuilder(RSAKey key) {
+        return new Builder(JWSAlgorithm.PS256).keyID(key.getKeyID());
+    }
+
+    private static Builder headerBuilderUsingCustomKeyId(String keyId) {
+        return new Builder(JWSAlgorithm.PS256).keyID(keyId);
+    }
+
+    private SignedJwt generateSignedJwt(RSAKey key, JWTClaimsSet claimsSet, JWSHeader.Builder jwsHeaderBuilder) {
+        try {
+            JWSSigner signer = new RSASSASigner(key);
+            SignedJWT signedJWT = new SignedJWT(jwsHeaderBuilder.build(), claimsSet);
+            signedJWT.sign(signer);
+            return new JwtReconstruction().reconstructJwt(signedJWT.serialize(), SignedJwt.class);
+        } catch (JOSEException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private void checkVerificationFails(SignedJwt jwt, JWKSet jwkSet, String expectedError) {
+        final SignatureException signatureException = assertThrows(SignatureException.class,
+                () -> signatureValidator.validateSignature(jwt, jwkSet));
+        assertThat(signatureException.getMessage()).contains(expectedError);
+    }
+
+    @Test
+    void verifyJwtWithValidSignaturePS256() throws SignatureException {
+        signatureValidator.validateSignature(generateSignedJwt(SIGNING_KEY, EXAMPLE_CLAIMS_SET), JWK_SET);
+    }
+
+    @Test
+    void verifyJwtWithValidSignaturePS384() throws SignatureException {
+        final SignedJwt ps384Jwt = generateSignedJwt(SIGNING_KEY, EXAMPLE_CLAIMS_SET,
+                                                     new Builder(JWSAlgorithm.PS384).keyID(SIGNING_KEY.getKeyID()));
+        signatureValidator.validateSignature(ps384Jwt, JWK_SET);
+    }
+
+    @Test
+    void verifyJwtWithValidSignaturePS512() throws SignatureException {
+        final SignedJwt ps512Jwt = generateSignedJwt(SIGNING_KEY, EXAMPLE_CLAIMS_SET,
+                                                     new Builder(JWSAlgorithm.PS512).keyID(SIGNING_KEY.getKeyID()));
+        signatureValidator.validateSignature(ps512Jwt, JWK_SET);
+    }
+
+    @Test
+    void verificationsFailsIfKeyUseIsNotSig() {
+        final SignedJwt jwt = generateSignedJwt(TRANSPORT_KEY, EXAMPLE_CLAIMS_SET);
+        checkVerificationFails(jwt, JWK_SET, "jwk for kid: " + TRANSPORT_KEY.getKeyID() + " must be signing key, instead found: enc");
+    }
+
+    @Test
+    void verificationFailsJwtSignatureInvalid() {
+        // Sign the JWT with the transport key, override the kid in the header to be that of the signing key, verification will fail as sig will not be valid for signing key
+        final SignedJwt signedJwt = generateSignedJwt(TRANSPORT_KEY, EXAMPLE_CLAIMS_SET, headerBuilderUsingCustomKeyId(SIGNING_KEY.getKeyID()));
+        checkVerificationFails(signedJwt, JWK_SET, "jwt signature verification failed");
+    }
+
+    @Test
+    void verificationFailsJwtSignatureInvalidDueToCorruptedPayload() throws JOSEException {
+        JWSSigner signer = new RSASSASigner(SIGNING_KEY);
+        SignedJWT signedJWT = new SignedJWT(defaultHeaderBuilder(SIGNING_KEY).build(), EXAMPLE_CLAIMS_SET);
+        signedJWT.sign(signer);
+        final String[] splitJwt = signedJWT.serialize().split("\\.");
+        String invalidJwt = splitJwt[0] + '.' + splitJwt[1] + "A." + splitJwt[2]; // Add an extra char to the end of the payload to corrupt it
+        checkVerificationFails(new JwtReconstruction().reconstructJwt(invalidJwt, SignedJwt.class), JWK_SET, "jwt signature verification failed");
+    }
+
+    @Test
+    void verificationFailsWhenKidNotInJwks() {
+        final SignedJwt jwt = generateSignedJwt(SIGNING_KEY, EXAMPLE_CLAIMS_SET, headerBuilderUsingCustomKeyId("unknown"));
+        checkVerificationFails(jwt, JWK_SET, "jwk not found in supplied jwkSet for kid");
+    }
+
+    @Test
+    void verificationFailsJwtHeaderMissingKid() {
+        final SignedJwt jwt = generateSignedJwt(SIGNING_KEY, EXAMPLE_CLAIMS_SET, headerBuilderUsingCustomKeyId(null));
+        checkVerificationFails(jwt, JWK_SET, "kid must be present in the JWT header");
+    }
+
+    @Test
+    void verificationFailsUnsupportedAlgorithm() {
+        final JWSAlgorithm unsupportedAlgo = JWSAlgorithm.RS256;
+        final SignedJwt jwt = generateSignedJwt(SIGNING_KEY, EXAMPLE_CLAIMS_SET, new JWSHeader.Builder(unsupportedAlgo).keyID(SIGNING_KEY.getKeyID()));
+        checkVerificationFails(jwt, JWK_SET, "jwt signed using unsupported algorithm: " + unsupportedAlgo.getName());
+    }
+
+    @Test
+    void verificationFailsIfNullParamsSupplied() {
+        checkVerificationFails(null, JWK_SET, "jwt must be supplied");
+        checkVerificationFails(generateSignedJwt(SIGNING_KEY, EXAMPLE_CLAIMS_SET), null, "jwkSet must be supplied");
+    }
+}


### PR DESCRIPTION
Adding RsaJwtSignatureValidator which validates that a SignedJwt's signature can be verified against a signing key in a supplied JWKSet

Calling the new validator from ProcessRegistration filter to verify the signature of the DCR JWT. 

Refactoring the SSAVerifier filter to use the new validator, instead of its validation written in groovy, to validate the signature of the SSA.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/624