### PR TITLE
673: Configuring x-ob-url header in IG

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -178,7 +178,8 @@
             "messageType" : "REQUEST",
             "remove" : [ "host", "X-Forwarded-Host" ],
             "add" : {
-              "X-Forwarded-Host" : [ "rs.dev.forgerock.financial" ]
+              "X-Forwarded-Host" : [ "rs.dev.forgerock.financial" ],
+              "x-ob-url": ["https://&{ig.fqdn}${contexts.router.remainingUri}"]
             }
           }
         }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -178,7 +178,8 @@
             "messageType" : "REQUEST",
             "remove" : [ "host", "X-Forwarded-Host" ],
             "add" : {
-              "X-Forwarded-Host" : [ "rs.dev.forgerock.financial" ]
+              "X-Forwarded-Host" : [ "rs.dev.forgerock.financial" ],
+              "x-ob-url": ["https://&{ig.fqdn}${contexts.router.remainingUri}"]
             }
           }
         }


### PR DESCRIPTION
Configuring the x-ob-url header required by the RS backends for account APIs.

Setting the value to match the IG route url as accessed by the TPP.

NOTE: contexts.router.originalUri could also be used, but it would need editing to replace the http:// with https:// (as nginx is terminating TLS in front of IG)

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/673