### PR TITLE
673: Configuring x-ob-url for all routes

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -95,6 +95,19 @@
               "type": "application/x-groovy",
               "file": "FapiTransactionIdFilter.groovy"
             }
+          },
+          {
+            "comment": "Add x-ob-url header",
+            "name": "HeaderFilter-Add-x-ob-url",
+            "type": "HeaderFilter",
+            "config": {
+              "messageType": "REQUEST",
+              "add": {
+                "x-ob-url": [
+                  "https://&{ig.fqdn}${contexts.router.remainingUri}"
+                ]
+              }
+            }
           }
         ]
       }


### PR DESCRIPTION
Configuring the x-ob-url header required by the RS backends for all routes.

NOTE: contexts.router.originalUri could also be used, but it would need editing to replace the http:// with https:// (as nginx is terminating TLS in front of IG)

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/673