### PR TITLE
674: Removing ObResponseCheck from AM token endpoint route

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
@@ -10,15 +10,6 @@
       "filters": [
         "SBATFapiInteractionFilterChain",
         {
-          "comment": "Ensure Open Banking compliant response",
-          "name": "ObResponseCheck",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ObResponseCheck.groovy"
-          }
-        },
-        {
           "comment": "Add host to downstream request",
           "name": "HeaderFilter-ChangeHostToIAM",
           "type": "HeaderFilter",


### PR DESCRIPTION
The ObResponseCheck filter should only be used for formatting error responses for calls to the Open Banking API.

Calls to the token endpoint should produce errors as per the OAuth2/OIDC specs (which is what AM produces).

Removing the ObResponseCheck filter from the token endpoint route so that the AM error response is propagated back to the caller.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/674