### PR TITLE
254: Fixing vrp consent route to use the correct issuer

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -90,7 +90,7 @@
                   "type": "StatelessAccessTokenResolver",
                   "config": {
                     "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                    "issuer": "https://&{ig.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
                     "verificationSecretId": "any.value.in.regex.format"
                   }
                 }
@@ -185,7 +185,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "SBATReverseProxyHandlerIdentityPlatform"
     }
   }
 }


### PR DESCRIPTION
FAPI changes were made in parallel with VRP route being developed, the route contains old configuration which needs to be updated so that the issuer is checking the IG domain.

Fixing to use the correct reverse proxy handler, consent route is reverse proxying IDM in this instance: SBATReverseProxyHandlerIdentityPlatform

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/254