### PR TITLE
641: Improve DCR error handling

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -67,8 +67,8 @@
             "clientHandler": "OBClientHandler",
             "args": {
               "routeArgSSAIssuerJwksUrls": {
-                "OpenBanking Ltd": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
-                "test-publisher": "https://&{ig.fqdn}/jwkms/apiclient/jwks"
+                "OpenBanking Ltd": "${urlDecode('https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks')}",
+                "test-publisher": "${urlDecode('https://&{ig.fqdn}/jwkms/apiclient/jwks')}"
               },
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -47,7 +47,9 @@
             "file": "ProcessRegistration.groovy",
             "args": {
               "comment": "TODO: use env variable",
-              "routeArgObJwksHosts": "[\"keystore.openbankingtest.org.uk\"]",
+              "routeArgObJwksHosts": [
+                "keystore.openbankingtest.org.uk"
+              ],
               "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy",
               "jwkSetService": "${heap['OBJwkSetService']}",
               "allowIgIssuedTestCerts": "${security.allowIgIssuedTestCerts}",

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -22,15 +22,12 @@ if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
 SCRIPT_NAME = "[ProcessRegistration] (" + fapiInteractionId + ") - "
 logger.debug(SCRIPT_NAME + "Running...")
 
-def errorCodeInvalidClientMetadata = "invalid_client_metadata"
-def errorCodeInvalidSoftwareStatement = "invalid_software_statement"
-
 def invalidClientMetadataErrorResponse(errorMessage) {
-    return errorResponse(Status.BAD_REQUEST, errorCodeInvalidClientMetadata, errorMessage)
+    return errorResponse(Status.BAD_REQUEST, "invalid_client_metadata", errorMessage)
 }
 
 def invalidSoftwareStatementErrorResponse(errorMessage) {
-    return errorResponse(Status.BAD_REQUEST, errorCodeInvalidSoftwareStatement, errorMessage)
+    return errorResponse(Status.BAD_REQUEST, "invalid_software_statement", errorMessage)
 }
 
 def errorResponse(httpCode, errorCode, errorMessage) {
@@ -84,10 +81,10 @@ switch(method.toUpperCase()) {
 
         def ssa = oidcRegistration.getClaim("software_statement", String.class);
         if (!ssa) {
-            return invalidSoftwareStatementErrorResponse("SSA claim is missing")
+            return invalidSoftwareStatementErrorResponse("software_statement claim is missing")
         }
         logger.debug(SCRIPT_NAME + "Got ssa [" + ssa + "]")
-        oidcRegistration.setClaim("software_statement",null);
+        oidcRegistration.setClaim("software_statement", null);
 
         def ssaJwt = new JwtReconstruction().reconstructJwt(ssa,SignedJwt.class)
         def ssaClaims = ssaJwt.getClaimsSet();
@@ -127,7 +124,7 @@ switch(method.toUpperCase()) {
                 // TODO review if this can be caught in IG conf
                 def jwksUri = null;
                 try {
-                    jwksUri = new URI(apiClientOrgJwksUri);
+                    jwksUri = new URI(apiClientOrgJwksUri)
                 }
                 catch (e) {
                     return errorResponse(Status.INTERNAL_SERVER_ERROR,"", "Invalid JWKS URI: " + apiClientOrgJwksUri)
@@ -136,7 +133,7 @@ switch(method.toUpperCase()) {
                 if (proxiedHosts.asList().contains(jwksUri.getHost())) {
                     def newUri = routeArgProxyBaseUrl + "/" + jwksUri.getHost() + jwksUri.getPath();
                     logger.debug(SCRIPT_NAME + "Updating private JWKS URI from {} to {}",apiClientOrgJwksUri,newUri);
-                    apiClientOrgJwksUri = newUri;
+                    apiClientOrgJwksUri = newUri
 
                 }
             }
@@ -151,7 +148,7 @@ switch(method.toUpperCase()) {
             oidcRegistration.setClaim("jwks",  apiClientOrgJwks )
         }
         else {
-            return invalidSoftwareStatementErrorResponse("No JWKS or JWKS URI in SSA")
+            return invalidSoftwareStatementErrorResponse("No JWKS or JWKS URI in software_statement")
         }
 
         // Store SSA and registration JWT for signature check

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -9,7 +9,7 @@ import groovy.json.JsonSlurper
 import com.forgerock.securebanking.uk.gateway.jwks.*
 import java.security.SignatureException
 import com.nimbusds.jose.jwk.RSAKey;
-import com.securebanking.gateway.DcrErrorResponseFactory
+import com.securebanking.gateway.dcr.ErrorResponseFactory
 import static org.forgerock.util.promise.Promises.newResultPromise
 
 /*
@@ -23,7 +23,7 @@ if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
 SCRIPT_NAME = "[ProcessRegistration] (" + fapiInteractionId + ") - "
 logger.debug(SCRIPT_NAME + "Running...")
 
-def errorResponseFactory = new DcrErrorResponseFactory(SCRIPT_NAME)
+def errorResponseFactory = new ErrorResponseFactory(SCRIPT_NAME)
 
 def defaultResponseTypes =  ["code id_token"]
 def supportedResponseTypes = [defaultResponseTypes]

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -22,12 +22,21 @@ if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
 SCRIPT_NAME = "[ProcessRegistration] (" + fapiInteractionId + ") - "
 logger.debug(SCRIPT_NAME + "Running...")
 
-def errorResponse(httpCode, message) {
-    logger.error(SCRIPT_NAME + "Returning error " + httpCode + ": " + message);
-    def response = new Response(httpCode);
-    response.headers['Content-Type'] = "application/json";
-    response.entity = "{ \"error\":\"" + message + "\"}";
-    return response;
+def errorCodeInvalidClientMetadata = "invalid_client_metadata"
+def errorCodeInvalidSoftwareStatement = "invalid_software_statement"
+
+def invalidClientMetadataErrorResponse(errorMessage) {
+    return errorResponse(Status.BAD_REQUEST, errorCodeInvalidClientMetadata, errorMessage)
+}
+
+def invalidSoftwareStatementErrorResponse(errorMessage) {
+    return errorResponse(Status.BAD_REQUEST, errorCodeInvalidSoftwareStatement, errorMessage)
+}
+
+def errorResponse(httpCode, errorCode, errorMessage) {
+    def response = new Response(httpCode)
+    response.entity.setJson([error: errorCode, error_description: errorMessage])
+    return response
 }
 
 def defaultResponseTypes =  ["code id_token"]
@@ -38,30 +47,22 @@ def method = request.method
 switch(method.toUpperCase()) {
     case "POST":
     case "PUT":
-        def error = false
-
         def SCOPE_ACCOUNTS = "accounts"
         def SCOPE_PAYMENTS = "payments"
-
-
         def ROLE_PAYMENT_INITIATION             = "0.4.0.19495.1.2"
         def ROLE_ACCOUNT_INFORMATION            = "0.4.0.19495.1.3"
         def ROLE_CARD_BASED_PAYMENT_INSTRUMENTS = "0.4.0.19495.1.4"
 
         // Check we have everything we need from the client certificate
-
         if (!attributes.clientCertificate) {
-            return(errorResponse(Status.BAD_REQUEST,"No client certificate for registration"));
+            return invalidClientMetadataErrorResponse("No client certificate for registration")
         }
-
         if (!attributes.clientCertificate.roles) {
-            return(errorResponse(Status.BAD_REQUEST,"No roles in client certificate for registration"));
+            return invalidClientMetadataErrorResponse("No roles in client certificate for registration")
         }
 
         // Parse incoming registration JWT
-
         logger.debug(SCRIPT_NAME + "Parsing registration request");
-
         def regJwt = new JwtReconstruction().reconstructJwt(request.entity.getString(),SignedJwt.class)
 
         // Pull the SSA from the reg data
@@ -71,26 +72,24 @@ switch(method.toUpperCase()) {
         // Valid exp claim
         Date expirationTime = oidcRegistration.getExpirationTime()
         if (expirationTime.before(new Date())) {
-            return errorResponse(Status.BAD_REQUEST,"registration has expired")
+            return invalidClientMetadataErrorResponse("registration has expired")
         }
 
         def responseTypes = oidcRegistration.getClaim("response_types")
         if (!responseTypes) {
             oidcRegistration.setClaim("response_types", defaultResponseTypes)
         } else if (!supportedResponseTypes.contains(responseTypes)) {
-            return errorResponse(Status.BAD_REQUEST, "response_types: " + responseTypes + " not supported")
+            return invalidClientMetadataErrorResponse("response_types: " + responseTypes + " not supported")
         }
 
         def ssa = oidcRegistration.getClaim("software_statement", String.class);
         if (!ssa) {
-            return(errorResponse(Status.BAD_REQUEST,"No SSA"));
+            return invalidSoftwareStatementErrorResponse("SSA claim is missing")
         }
+        logger.debug(SCRIPT_NAME + "Got ssa [" + ssa + "]")
         oidcRegistration.setClaim("software_statement",null);
 
-        logger.debug(SCRIPT_NAME + "Got ssa [" + ssa + "]")
-
         def ssaJwt = new JwtReconstruction().reconstructJwt(ssa,SignedJwt.class)
-
         def ssaClaims = ssaJwt.getClaimsSet();
 
         // Validate the issuer claim for the registration matches the SSA software_id
@@ -99,7 +98,7 @@ switch(method.toUpperCase()) {
         def registrationIssuer = oidcRegistration.getIssuer()
         def ssaSoftwareId = ssaClaims.getClaim("software_id")
         if (registrationIssuer == null || ssaSoftwareId == null || registrationIssuer != ssaSoftwareId) {
-            return errorResponse(Status.BAD_REQUEST,"invalid issuer claim")
+            return invalidClientMetadataErrorResponse("invalid issuer claim")
         }
 
         def apiClientOrgName = ssaClaims.getClaim("software_client_name", String.class);
@@ -118,21 +117,20 @@ switch(method.toUpperCase()) {
         if (apiClientOrgJwksUri) {
             logger.debug(SCRIPT_NAME + "Using jwks uri")
             if (routeArgObJwksHosts) {
-
                 // If the JWKS URI host is in our list of private JWKS hosts, then proxy back through IG
-
                 def slurper = new JsonSlurper()
                 def proxiedHosts = slurper.parseText(routeArgObJwksHosts);
-
+                // TODO Review this error, can we catch it at IG start up by doing the parse in the config?
                 if (!proxiedHosts) {
-                    return(errorResponse(Status.INTERNAL_SERVER_ERROR,"Could not parse proxied jwks hosts"));
+                    return errorResponse(Status.INTERNAL_SERVER_ERROR, "", "Could not parse proxied jwks hosts")
                 }
+                // TODO review if this can be caught in IG conf
                 def jwksUri = null;
                 try {
                     jwksUri = new URI(apiClientOrgJwksUri);
                 }
                 catch (e) {
-                    return(errorResponse(Status.BAD_REQUEST,"Invalid JWKS URI: " + apiClientOrgJwksUri));
+                    return errorResponse(Status.INTERNAL_SERVER_ERROR,"", "Invalid JWKS URI: " + apiClientOrgJwksUri)
                 }
 
                 if (proxiedHosts.asList().contains(jwksUri.getHost())) {
@@ -147,17 +145,16 @@ switch(method.toUpperCase()) {
         else if (apiClientOrgJwks) {
             if (!allowIgIssuedTestCerts) {
                 logger.debug(SCRIPT_NAME + "configuration to allowIgIssuedTestCerts is disabled")
-                return(errorResponse(Status.BAD_REQUEST, "software_statement must contain software_jwks_endpoint"));
+                return invalidSoftwareStatementErrorResponse("software_statement must contain software_jwks_endpoint")
             }
             logger.debug(SCRIPT_NAME + "Using jwks from software_statement")
             oidcRegistration.setClaim("jwks",  apiClientOrgJwks )
         }
         else {
-            return(errorResponse(Status.BAD_REQUEST,"No JWKS or JWKS URI in SSA"));
+            return invalidSoftwareStatementErrorResponse("No JWKS or JWKS URI in SSA")
         }
 
         // Store SSA and registration JWT for signature check
-
         attributes.registrationJWTs = [
                 "ssaStr": ssa,
                 "ssaJwt" : ssaJwt,
@@ -175,32 +172,26 @@ switch(method.toUpperCase()) {
         }
 
         // Sanity check on scopes
-
         def scopes = oidcRegistration.getClaim("scope")
         def roles = attributes.clientCertificate.roles
-
         if (scopes.contains(SCOPE_ACCOUNTS) && !(roles.contains(ROLE_ACCOUNT_INFORMATION))) {
-            return(errorResponse(Status.BAD_REQUEST,"Requested scope " + SCOPE_ACCOUNTS + " requires certificate role " + ROLE_ACCOUNT_INFORMATION));
+            return invalidClientMetadataErrorResponse("Requested scope " + SCOPE_ACCOUNTS + " requires certificate role " + ROLE_ACCOUNT_INFORMATION)
         }
-
         if (scopes.contains(SCOPE_PAYMENTS) && !(roles.contains(ROLE_PAYMENT_INITIATION))) {
-            return(errorResponse(Status.BAD_REQUEST,"Requested scope " + SCOPE_PAYMENTS + " requires certificate role " + ROLE_PAYMENT_INITIATION));
+            return invalidClientMetadataErrorResponse("Requested scope " + SCOPE_PAYMENTS + " requires certificate role " + ROLE_PAYMENT_INITIATION)
         }
 
         // Cross check ID with cert
         //
         // e.g. PSDGB-FFA-5f563e89742b2800145c7da1 or PSDGB-OB-Unknown0015800001041REAAY (issue by OB)
-
         def  organizationalIdentifier = attributes.clientCertificate.subjectDNComponents.OI
-
         if (!organizationalIdentifier) {
-            return(errorResponse(Status.BAD_REQUEST,"No organizational identifier in cert"));
+            return invalidClientMetadataErrorResponse("No organizational identifier in cert")
         }
 
         def oiComponents = organizationalIdentifier.split("-")
-
         if (oiComponents.length > 3) {
-            return(errorResponse(Status.BAD_REQUEST,"Wrong number of dashes in OI " + organizationalIdentifier +" - expected 2"));
+            return invalidClientMetadataErrorResponse("Wrong number of dashes in OI " + organizationalIdentifier +" - expected 2")
         }
 
         // TODO: Subject DN for cert bound access tokens
@@ -220,15 +211,15 @@ switch(method.toUpperCase()) {
             logger.debug(SCRIPT_NAME + "Checking cert against remote jwks: " + apiClientOrgJwksUri)
             return jwkSetService.getJwkSet(new URL(apiClientOrgJwksUri))
                                 .thenCatchAsync(e -> {
-                                    logger.debug(SCRIPT_NAME + "failed to get jwks due to exception", e)
-                                    return newResultPromise(errorResponse(Status.BAD_REQUEST, "unable to get jwks from url: " + apiClientOrgJwksUri))
+                                    logger.warn(SCRIPT_NAME + "failed to get jwks due to exception", e)
+                                    return newResultPromise(invalidClientMetadataErrorResponse("unable to get jwks from url: " + apiClientOrgJwksUri))
                                 })
                                 .thenAsync(jwkSet -> {
                                     if (!tlsClientCertExistsInJwkSet(jwkSet)) {
-                                        return newResultPromise(errorResponse(Status.BAD_REQUEST, "tls transport cert does not match any certs registered in jwks for software statement"))
+                                        return newResultPromise(invalidSoftwareStatementErrorResponse("tls transport cert does not match any certs registered in jwks for software statement"))
                                     }
                                     if (!validateRegistrationJwtSignature(regJwt, jwkSet)) {
-                                        return newResultPromise(errorResponse(Status.BAD_REQUEST, "registration JWT signature invalid"))
+                                        return newResultPromise(invalidClientMetadataErrorResponse("registration JWT signature invalid"))
                                     }
                                     return next.handle(context, request)
                                                .thenOnResult(response -> addSoftwareStatementToResponse(response, ssa))
@@ -238,15 +229,15 @@ switch(method.toUpperCase()) {
             // Verify against the software_jwks which is a JWKSet embedded within the software_statement
             // NOTE: this is only suitable for developer testing purposes
             if (!allowIgIssuedTestCerts) {
-                return(errorResponse(Status.BAD_REQUEST, "software_statement must contain software_jwks_endpoint"));
+                return invalidSoftwareStatementErrorResponse("software_statement must contain software_jwks_endpoint")
             }
             logger.debug(SCRIPT_NAME + "Checking cert against ssa software_jwks: " + apiClientOrgJwks)
             def jwkSet = new JWKSet(new JsonValue(apiClientOrgJwks.get("keys")))
             if (!tlsClientCertExistsInJwkSet(jwkSet)) {
-                return newResultPromise(errorResponse(Status.BAD_REQUEST, "tls transport cert does not match any certs registered in jwks for software statement"))
+                return newResultPromise(invalidSoftwareStatementErrorResponse( "tls transport cert does not match any certs registered in jwks for software statement"))
             }
             if (!validateRegistrationJwtSignature(regJwt, jwkSet)) {
-                return newResultPromise(errorResponse(Status.BAD_REQUEST, "registration JWT signature invalid"))
+                return newResultPromise(invalidClientMetadataErrorResponse("registration JWT signature invalid"))
             }
             return next.handle(context, request)
                        .thenOnResult(response -> addSoftwareStatementToResponse(response, ssa))
@@ -316,7 +307,7 @@ private boolean validateRegistrationJwtSignature(jwt, jwkSet) {
         jwtSignatureValidator.validateSignature(jwt, jwkSet)
         return true
     } catch (SignatureException se) {
-        logger.error(SCRIPT_NAME + "jwt signature validation failed", se)
+        logger.warn(SCRIPT_NAME + "jwt signature validation failed", se)
         return false
     }
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -123,6 +123,15 @@ switch(method.toUpperCase()) {
                 if (!proxiedHosts) {
                     return errorResponse(Status.INTERNAL_SERVER_ERROR, "", "Could not parse proxied jwks hosts")
                 }
+                // TODO review if this can be caught in IG conf
+                def jwksUri = null;
+                try {
+                    jwksUri = new URI(apiClientOrgJwksUri)
+                }
+                catch (e) {
+                    return errorResponse(Status.INTERNAL_SERVER_ERROR,"", "Invalid JWKS URI: " + apiClientOrgJwksUri)
+                }
+
                 if (proxiedHosts.asList().contains(jwksUri.getHost())) {
                     def newUri = routeArgProxyBaseUrl + "/" + jwksUri.getHost() + jwksUri.getPath();
                     logger.debug(SCRIPT_NAME + "Updating private JWKS URI from {} to {}",apiClientOrgJwksUri,newUri);

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -122,7 +122,7 @@ switch(method.toUpperCase()) {
                     jwksUri = new URI(apiClientOrgJwksUri)
                 }
                 catch (e) {
-                    return invalidSoftwareStatementErrorResponse("apiClientOrgJwksUri does not contain a valid URI")
+                    return invalidSoftwareStatementErrorResponse("software_jwks_endpoint does not contain a valid URI")
                 }
                 // If the JWKS URI host is in our list of private JWKS hosts, then proxy back through IG
                 if (routeArgObJwksHosts && routeArgObJwksHosts.contains(jwksUri.getHost())) {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -114,27 +114,20 @@ switch(method.toUpperCase()) {
 
         // Update OIDC registration request
         if (apiClientOrgJwksUri) {
-            logger.debug(SCRIPT_NAME + "Using jwks uri")
+            logger.debug(SCRIPT_NAME + "Using jwks uri: {}", apiClientOrgJwksUri)
             if (routeArgObJwksHosts) {
                 // If the JWKS URI host is in our list of private JWKS hosts, then proxy back through IG
-                def slurper = new JsonSlurper()
-                def proxiedHosts = slurper.parseText(routeArgObJwksHosts);
-                // TODO Review this error, can we catch it at IG start up by doing the parse in the config?
-                if (!proxiedHosts) {
-                    return errorResponse(Status.INTERNAL_SERVER_ERROR, "", "Could not parse proxied jwks hosts")
-                }
-                // TODO review if this can be caught in IG conf
                 def jwksUri = null;
                 try {
                     jwksUri = new URI(apiClientOrgJwksUri)
                 }
                 catch (e) {
-                    return errorResponse(Status.INTERNAL_SERVER_ERROR,"", "Invalid JWKS URI: " + apiClientOrgJwksUri)
+                    return invalidSoftwareStatementErrorResponse("apiClientOrgJwksUri does not contain a valid URI")
                 }
-
-                if (proxiedHosts.asList().contains(jwksUri.getHost())) {
+                // If the JWKS URI host is in our list of private JWKS hosts, then proxy back through IG
+                if (routeArgObJwksHosts && routeArgObJwksHosts.contains(jwksUri.getHost())) {
                     def newUri = routeArgProxyBaseUrl + "/" + jwksUri.getHost() + jwksUri.getPath();
-                    logger.debug(SCRIPT_NAME + "Updating private JWKS URI from {} to {}",apiClientOrgJwksUri,newUri);
+                    logger.debug(SCRIPT_NAME + "Updating private JWKS URI from {} to {}", apiClientOrgJwksUri, newUri);
                     apiClientOrgJwksUri = newUri
 
                 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -31,8 +31,10 @@ def invalidSoftwareStatementErrorResponse(errorMessage) {
 }
 
 def errorResponse(httpCode, errorCode, errorMessage) {
+    def errorMsgJson = [error: errorCode, error_description: errorMessage]
+    logger.warn(SCRIPT_NAME + "DCR failed, http status: {}, error: {}", httpCode, errorMsgJson)
     def response = new Response(httpCode)
-    response.entity.setJson([error: errorCode, error_description: errorMessage])
+    response.entity.setJson(errorMsgJson)
     return response
 }
 

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -123,15 +123,6 @@ switch(method.toUpperCase()) {
                 if (!proxiedHosts) {
                     return errorResponse(Status.INTERNAL_SERVER_ERROR, "", "Could not parse proxied jwks hosts")
                 }
-                // TODO review if this can be caught in IG conf
-                def jwksUri = null;
-                try {
-                    jwksUri = new URI(apiClientOrgJwksUri)
-                }
-                catch (e) {
-                    return errorResponse(Status.INTERNAL_SERVER_ERROR,"", "Invalid JWKS URI: " + apiClientOrgJwksUri)
-                }
-
                 if (proxiedHosts.asList().contains(jwksUri.getHost())) {
                     def newUri = routeArgProxyBaseUrl + "/" + jwksUri.getHost() + jwksUri.getPath();
                     logger.debug(SCRIPT_NAME + "Updating private JWKS URI from {} to {}",apiClientOrgJwksUri,newUri);

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -9,6 +9,7 @@ import groovy.json.JsonSlurper
 import com.forgerock.securebanking.uk.gateway.jwks.*
 import java.security.SignatureException
 import com.nimbusds.jose.jwk.RSAKey;
+import com.securebanking.gateway.DcrErrorResponseFactory
 import static org.forgerock.util.promise.Promises.newResultPromise
 
 /*
@@ -22,21 +23,7 @@ if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
 SCRIPT_NAME = "[ProcessRegistration] (" + fapiInteractionId + ") - "
 logger.debug(SCRIPT_NAME + "Running...")
 
-def invalidClientMetadataErrorResponse(errorMessage) {
-    return errorResponse(Status.BAD_REQUEST, "invalid_client_metadata", errorMessage)
-}
-
-def invalidSoftwareStatementErrorResponse(errorMessage) {
-    return errorResponse(Status.BAD_REQUEST, "invalid_software_statement", errorMessage)
-}
-
-def errorResponse(httpCode, errorCode, errorMessage) {
-    def errorMsgJson = [error: errorCode, error_description: errorMessage]
-    logger.warn(SCRIPT_NAME + "DCR failed, http status: {}, error: {}", httpCode, errorMsgJson)
-    def response = new Response(httpCode)
-    response.entity.setJson(errorMsgJson)
-    return response
-}
+def errorResponseFactory = new DcrErrorResponseFactory(SCRIPT_NAME)
 
 def defaultResponseTypes =  ["code id_token"]
 def supportedResponseTypes = [defaultResponseTypes]
@@ -54,10 +41,10 @@ switch(method.toUpperCase()) {
 
         // Check we have everything we need from the client certificate
         if (!attributes.clientCertificate) {
-            return invalidClientMetadataErrorResponse("No client certificate for registration")
+            return errorResponseFactory.invalidClientMetadataErrorResponse("No client certificate for registration")
         }
         if (!attributes.clientCertificate.roles) {
-            return invalidClientMetadataErrorResponse("No roles in client certificate for registration")
+            return errorResponseFactory.invalidClientMetadataErrorResponse("No roles in client certificate for registration")
         }
 
         // Parse incoming registration JWT
@@ -71,19 +58,19 @@ switch(method.toUpperCase()) {
         // Valid exp claim
         Date expirationTime = oidcRegistration.getExpirationTime()
         if (expirationTime.before(new Date())) {
-            return invalidClientMetadataErrorResponse("registration has expired")
+            return errorResponseFactory.invalidClientMetadataErrorResponse("registration has expired")
         }
 
         def responseTypes = oidcRegistration.getClaim("response_types")
         if (!responseTypes) {
             oidcRegistration.setClaim("response_types", defaultResponseTypes)
         } else if (!supportedResponseTypes.contains(responseTypes)) {
-            return invalidClientMetadataErrorResponse("response_types: " + responseTypes + " not supported")
+            return errorResponseFactory.invalidClientMetadataErrorResponse("response_types: " + responseTypes + " not supported")
         }
 
         def ssa = oidcRegistration.getClaim("software_statement", String.class);
         if (!ssa) {
-            return invalidSoftwareStatementErrorResponse("software_statement claim is missing")
+            return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_statement claim is missing")
         }
         logger.debug(SCRIPT_NAME + "Got ssa [" + ssa + "]")
         oidcRegistration.setClaim("software_statement", null);
@@ -97,7 +84,7 @@ switch(method.toUpperCase()) {
         def registrationIssuer = oidcRegistration.getIssuer()
         def ssaSoftwareId = ssaClaims.getClaim("software_id")
         if (registrationIssuer == null || ssaSoftwareId == null || registrationIssuer != ssaSoftwareId) {
-            return invalidClientMetadataErrorResponse("invalid issuer claim")
+            return errorResponseFactory.invalidClientMetadataErrorResponse("invalid issuer claim")
         }
 
         def apiClientOrgName = ssaClaims.getClaim("software_client_name", String.class);
@@ -122,7 +109,7 @@ switch(method.toUpperCase()) {
                     jwksUri = new URI(apiClientOrgJwksUri)
                 }
                 catch (e) {
-                    return invalidSoftwareStatementErrorResponse("software_jwks_endpoint does not contain a valid URI")
+                    return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_jwks_endpoint does not contain a valid URI")
                 }
                 // If the JWKS URI host is in our list of private JWKS hosts, then proxy back through IG
                 if (routeArgObJwksHosts && routeArgObJwksHosts.contains(jwksUri.getHost())) {
@@ -137,13 +124,13 @@ switch(method.toUpperCase()) {
         else if (apiClientOrgJwks) {
             if (!allowIgIssuedTestCerts) {
                 logger.debug(SCRIPT_NAME + "configuration to allowIgIssuedTestCerts is disabled")
-                return invalidSoftwareStatementErrorResponse("software_statement must contain software_jwks_endpoint")
+                return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_statement must contain software_jwks_endpoint")
             }
             logger.debug(SCRIPT_NAME + "Using jwks from software_statement")
             oidcRegistration.setClaim("jwks",  apiClientOrgJwks )
         }
         else {
-            return invalidSoftwareStatementErrorResponse("No JWKS or JWKS URI in software_statement")
+            return errorResponseFactory.invalidSoftwareStatementErrorResponse("No JWKS or JWKS URI in software_statement")
         }
 
         // Store SSA and registration JWT for signature check
@@ -167,10 +154,10 @@ switch(method.toUpperCase()) {
         def scopes = oidcRegistration.getClaim("scope")
         def roles = attributes.clientCertificate.roles
         if (scopes.contains(SCOPE_ACCOUNTS) && !(roles.contains(ROLE_ACCOUNT_INFORMATION))) {
-            return invalidClientMetadataErrorResponse("Requested scope " + SCOPE_ACCOUNTS + " requires certificate role " + ROLE_ACCOUNT_INFORMATION)
+            return errorResponseFactory.invalidClientMetadataErrorResponse("Requested scope " + SCOPE_ACCOUNTS + " requires certificate role " + ROLE_ACCOUNT_INFORMATION)
         }
         if (scopes.contains(SCOPE_PAYMENTS) && !(roles.contains(ROLE_PAYMENT_INITIATION))) {
-            return invalidClientMetadataErrorResponse("Requested scope " + SCOPE_PAYMENTS + " requires certificate role " + ROLE_PAYMENT_INITIATION)
+            return errorResponseFactory.invalidClientMetadataErrorResponse("Requested scope " + SCOPE_PAYMENTS + " requires certificate role " + ROLE_PAYMENT_INITIATION)
         }
 
         // Cross check ID with cert
@@ -178,12 +165,12 @@ switch(method.toUpperCase()) {
         // e.g. PSDGB-FFA-5f563e89742b2800145c7da1 or PSDGB-OB-Unknown0015800001041REAAY (issue by OB)
         def  organizationalIdentifier = attributes.clientCertificate.subjectDNComponents.OI
         if (!organizationalIdentifier) {
-            return invalidClientMetadataErrorResponse("No organizational identifier in cert")
+            return errorResponseFactory.invalidClientMetadataErrorResponse("No organizational identifier in cert")
         }
 
         def oiComponents = organizationalIdentifier.split("-")
         if (oiComponents.length > 3) {
-            return invalidClientMetadataErrorResponse("Wrong number of dashes in OI " + organizationalIdentifier +" - expected 2")
+            return errorResponseFactory.invalidClientMetadataErrorResponse("Wrong number of dashes in OI " + organizationalIdentifier +" - expected 2")
         }
 
         // TODO: Subject DN for cert bound access tokens
@@ -204,14 +191,14 @@ switch(method.toUpperCase()) {
             return jwkSetService.getJwkSet(new URL(apiClientOrgJwksUri))
                                 .thenCatchAsync(e -> {
                                     logger.warn(SCRIPT_NAME + "failed to get jwks due to exception", e)
-                                    return newResultPromise(invalidClientMetadataErrorResponse("unable to get jwks from url: " + apiClientOrgJwksUri))
+                                    return newResultPromise(errorResponseFactory.invalidClientMetadataErrorResponse("unable to get jwks from url: " + apiClientOrgJwksUri))
                                 })
                                 .thenAsync(jwkSet -> {
                                     if (!tlsClientCertExistsInJwkSet(jwkSet)) {
-                                        return newResultPromise(invalidSoftwareStatementErrorResponse("tls transport cert does not match any certs registered in jwks for software statement"))
+                                        return newResultPromise(errorResponseFactory.invalidSoftwareStatementErrorResponse("tls transport cert does not match any certs registered in jwks for software statement"))
                                     }
                                     if (!validateRegistrationJwtSignature(regJwt, jwkSet)) {
-                                        return newResultPromise(invalidClientMetadataErrorResponse("registration JWT signature invalid"))
+                                        return newResultPromise(errorResponseFactory.invalidClientMetadataErrorResponse("registration JWT signature invalid"))
                                     }
                                     return next.handle(context, request)
                                                .thenOnResult(response -> addSoftwareStatementToResponse(response, ssa))
@@ -221,15 +208,15 @@ switch(method.toUpperCase()) {
             // Verify against the software_jwks which is a JWKSet embedded within the software_statement
             // NOTE: this is only suitable for developer testing purposes
             if (!allowIgIssuedTestCerts) {
-                return invalidSoftwareStatementErrorResponse("software_statement must contain software_jwks_endpoint")
+                return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_statement must contain software_jwks_endpoint")
             }
             logger.debug(SCRIPT_NAME + "Checking cert against ssa software_jwks: " + apiClientOrgJwks)
             def jwkSet = new JWKSet(new JsonValue(apiClientOrgJwks.get("keys")))
             if (!tlsClientCertExistsInJwkSet(jwkSet)) {
-                return newResultPromise(invalidSoftwareStatementErrorResponse( "tls transport cert does not match any certs registered in jwks for software statement"))
+                return newResultPromise(errorResponseFactory.invalidSoftwareStatementErrorResponse( "tls transport cert does not match any certs registered in jwks for software statement"))
             }
             if (!validateRegistrationJwtSignature(regJwt, jwkSet)) {
-                return newResultPromise(invalidClientMetadataErrorResponse("registration JWT signature invalid"))
+                return newResultPromise(errorResponseFactory.invalidClientMetadataErrorResponse("registration JWT signature invalid"))
             }
             return next.handle(context, request)
                        .thenOnResult(response -> addSoftwareStatementToResponse(response, ssa))

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -146,7 +146,7 @@ switch(method.toUpperCase()) {
         }
         else if (apiClientOrgJwks) {
             if (!allowIgIssuedTestCerts) {
-                logger.debug("configuration to allowIgIssuedTestCerts is disabled")
+                logger.debug(SCRIPT_NAME + "configuration to allowIgIssuedTestCerts is disabled")
                 return(errorResponse(Status.BAD_REQUEST, "software_statement must contain software_jwks_endpoint"));
             }
             logger.debug(SCRIPT_NAME + "Using jwks from software_statement")
@@ -316,7 +316,7 @@ private boolean validateRegistrationJwtSignature(jwt, jwkSet) {
         jwtSignatureValidator.validateSignature(jwt, jwkSet)
         return true
     } catch (SignatureException se) {
-        logger.error("jwt signature validation failed", se)
+        logger.error(SCRIPT_NAME + "jwt signature validation failed", se)
         return false
     }
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -17,7 +17,7 @@ def verifySignature(signedJwt, jwksJson) {
         jwtSignatureValidator.validateSignature(signedJwt, jwks)
         return true
     } catch (SignatureException se) {
-        logger.error("jwt signature validation failed", se)
+        logger.error(SCRIPT_NAME + "jwt signature validation failed", se)
         return false
     }
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -2,7 +2,7 @@ import org.forgerock.json.jose.jwk.JWKSet;
 import org.forgerock.http.protocol.Status;
 import java.net.URI;
 import java.security.SignatureException
-import com.securebanking.gateway.DcrErrorResponseFactory
+import com.securebanking.gateway.dcr.ErrorResponseFactory
 import static org.forgerock.util.promise.Promises.newResultPromise
 
 def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
@@ -22,7 +22,7 @@ def verifySignature(signedJwt, jwksJson) {
     }
 }
 
-def errorResponseFactory = new DcrErrorResponseFactory(SCRIPT_NAME)
+def errorResponseFactory = new ErrorResponseFactory(SCRIPT_NAME)
 
 def method = request.method
 switch(method.toUpperCase()) {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/securebanking/gateway/DcrErrorResponseFactory.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/securebanking/gateway/DcrErrorResponseFactory.groovy
@@ -1,0 +1,48 @@
+package com.securebanking.gateway
+
+import org.forgerock.util.promise.*
+import org.forgerock.http.protocol.*
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory which creates Response objects for error states when validating a DCR (Dynamic Client Registration) request
+ */
+class DcrErrorResponseFactory {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass())
+    /**
+     * Prefix for log messages created by this factory.
+     * This is allows the x-fapi-interaction-id to be logged.
+     */
+    private final String logPrefix
+
+    public DcrErrorResponseFactory(String logPrefix) {
+        this.logPrefix = logPrefix
+    }
+
+    def invalidClientMetadataErrorResponse(errorMessage) {
+        return errorResponse(Status.BAD_REQUEST, "invalid_client_metadata", errorMessage)
+    }
+
+    def invalidSoftwareStatementErrorResponse(errorMessage) {
+        return errorResponse(Status.BAD_REQUEST, "invalid_software_statement", errorMessage)
+    }
+
+    def errorResponse(httpCode, errorMessage) {
+        return errorResponse(httpCode, null, errorMessage)
+    }
+
+    def errorResponse(httpCode, errorCode, errorMessage) {
+        def errorMsgJson = new LinkedHashMap()
+        if (errorCode) {
+            errorMsgJson["error"] = errorCode
+        }
+        errorMsgJson["error_description"] = errorMessage
+        logger.warn("{}DCR failed, http status: {}, error: {}", logPrefix, httpCode, errorMsgJson)
+        def response = new Response(httpCode)
+        response.entity.setJson(errorMsgJson)
+        return response
+    }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/securebanking/gateway/dcr/ErrorResponseFactory.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/securebanking/gateway/dcr/ErrorResponseFactory.groovy
@@ -1,15 +1,15 @@
-package com.securebanking.gateway
+package com.securebanking.gateway.dcr
 
 import org.forgerock.util.promise.*
 import org.forgerock.http.protocol.*
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * Factory which creates Response objects for error states when validating a DCR (Dynamic Client Registration) request
  */
-class DcrErrorResponseFactory {
+class ErrorResponseFactory {
 
     private final Logger logger = LoggerFactory.getLogger(getClass())
     /**
@@ -18,7 +18,7 @@ class DcrErrorResponseFactory {
      */
     private final String logPrefix
 
-    public DcrErrorResponseFactory(String logPrefix) {
+    public ErrorResponseFactory(String logPrefix) {
         this.logPrefix = logPrefix
     }
 


### PR DESCRIPTION
Improving DCR error handling by creating an error factory which can be used to consistently report DCR errors. The error format for bad client requests adheres to the spec: https://www.rfc-editor.org/rfc/rfc7591#section-3.2.2

[ErrorResponseFactory](https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-gateway/blob/6b5b3f7e1c138d22463736d5b0850432362b98b4/config/7.1.0/securebanking/ig/scripts/groovy/com/securebanking/gateway/dcr/ErrorResponseFactory.groovy) is a groovy class which is imported into the ProcessRegistration and SSAVerifier filter scripts which make up the core DCR logic. 

This pattern can be applied to reuse logic between groovy filters. To do this place groovy classes under scripts/groovy dir in a standard groovy package structure. You can then import the class in scripts as you would any other groovy/java class  in this case: `import com.securebanking.gateway.dcr.ErrorResponseFactory`


Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/641